### PR TITLE
feat: Add Adversarial mode with unique gameplay mechanics and localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a fully-featured implementation of the classic 2048 puzzle game, built w
 - 💾 Auto-save and resume game state
 - 🏆 Best score tracking
 - 🧩 Multiple board sizes (3x3 through 8x8)
-- 🧱 Multiple game modes (Modern + Classic + Walltastrophy)
+- 🧱 Multiple game modes (Modern + Classic + Walltastrophy + Adversarial)
 - 🧠 Optional Move Coach (recommended direction + reason)
 - 🛟 Coach Nudges when you're stuck (optional)
 - 👆 Swipe preview (slow-drag previews a move before committing)
@@ -125,6 +125,7 @@ Create the following leaderboards:
 
 | Leaderboard ID | Name | Score Format | Sort Order |
 | --- | --- | --- | --- |
+| `com.dappermagna.twentyfortyeight.highscores.3x3` | Classic 3×3 High Scores | Integer | High to Low |
 | `com.dappermagna.twentyfortyeight.highscores.4x4` | Classic 4×4 High Scores | Integer | High to Low |
 | `com.dappermagna.twentyfortyeight.highscores.5x5` | Classic 5×5 High Scores | Integer | High to Low |
 | `com.dappermagna.twentyfortyeight.highscores.6x6` | Classic 6×6 High Scores | Integer | High to Low |
@@ -135,6 +136,7 @@ Create the following leaderboards:
 
 | Leaderboard ID | Name | Score Format | Sort Order |
 | --- | --- | --- | --- |
+| `com.dappermagna.twentyfortyeight.highscores.modern.3x3` | Modern 3×3 High Scores | Integer | High to Low |
 | `com.dappermagna.twentyfortyeight.highscores.modern.4x4` | Modern 4×4 High Scores | Integer | High to Low |
 | `com.dappermagna.twentyfortyeight.highscores.modern.5x5` | Modern 5×5 High Scores | Integer | High to Low |
 | `com.dappermagna.twentyfortyeight.highscores.modern.6x6` | Modern 6×6 High Scores | Integer | High to Low |
@@ -145,11 +147,25 @@ Create the following leaderboards:
 
 | Leaderboard ID | Name | Score Format | Sort Order |
 | --- | --- | --- | --- |
+| `com.dappermagna.twentyfortyeight.highscores.walltastrophy.3x3` | Walltastrophy 3×3 High Scores | Integer | High to Low |
 | `com.dappermagna.twentyfortyeight.highscores.walltastrophy.4x4` | Walltastrophy 4×4 High Scores | Integer | High to Low |
 | `com.dappermagna.twentyfortyeight.highscores.walltastrophy.5x5` | Walltastrophy 5×5 High Scores | Integer | High to Low |
 | `com.dappermagna.twentyfortyeight.highscores.walltastrophy.6x6` | Walltastrophy 6×6 High Scores | Integer | High to Low |
 | `com.dappermagna.twentyfortyeight.highscores.walltastrophy.7x7` | Walltastrophy 7×7 High Scores | Integer | High to Low |
 | `com.dappermagna.twentyfortyeight.highscores.walltastrophy.8x8` | Walltastrophy 8×8 High Scores | Integer | High to Low |
+
+#### Adversarial Mode Leaderboards
+
+Adversarial mode is scored using normal 2048 merge scoring, but the objective is inverted: **lower score is better**. Configure these leaderboards with **Low to High** sort order.
+
+| Leaderboard ID | Name | Score Format | Sort Order |
+| --- | --- | --- | --- |
+| `com.dappermagna.twentyfortyeight.highscores.adversarial.3x3` | Adversarial 3×3 Low Scores | Integer | Low to High |
+| `com.dappermagna.twentyfortyeight.highscores.adversarial.4x4` | Adversarial 4×4 Low Scores | Integer | Low to High |
+| `com.dappermagna.twentyfortyeight.highscores.adversarial.5x5` | Adversarial 5×5 Low Scores | Integer | Low to High |
+| `com.dappermagna.twentyfortyeight.highscores.adversarial.6x6` | Adversarial 6×6 Low Scores | Integer | Low to High |
+| `com.dappermagna.twentyfortyeight.highscores.adversarial.7x7` | Adversarial 7×7 Low Scores | Integer | Low to High |
+| `com.dappermagna.twentyfortyeight.highscores.adversarial.8x8` | Adversarial 8×8 Low Scores | Integer | Low to High |
 
 **Note:** Only the default win tile (2048) is supported for leaderboard submissions. Custom win tiles do not submit scores to leaderboards.
 
@@ -189,7 +205,7 @@ A fully-testable, UI-independent game engine that implements the classic 2048 ru
 - Game2048Engine: move logic, merge rules, win/game-over detection
 - GameState: immutable state representation for undo/redo
 - GameConfig: configurable board size + win conditions
-- GameMode: ruleset variants (Modern, Classic, Walltastrophy)
+- GameMode: ruleset variants (Modern, Classic, Walltastrophy, Adversarial)
 - IRandomSource: abstraction for deterministic testing
 - GameStateDto: JSON-friendly serialization for persistence
 - MoveAnalyzer / HeuristicMoveAdvisor: platform-agnostic move analysis and coaching
@@ -242,6 +258,15 @@ Comprehensive test suite using MSTest covering:
 5. New Tiles: After each move, a new tile appears in a random empty spot (value depends on game mode)
 6. Winning: Reach the 2048 tile (game can continue after winning)
 7. Game Over: No more valid moves available
+
+### Adversarial Mode
+
+Adversarial mode flips the role: **you place tiles to try to block the AI**.
+
+- Input: Tap an empty cell to spawn a random `2` or `4`, then the AI automatically makes one move.
+- Win: The AI has no legal moves (board is locked).
+- Loss: The AI creates the win tile (2048 by default).
+- Scoring: Standard 2048 merge scoring (non-negative), but **lower final score is better**.
 
 ## CI/CD
 

--- a/src/TwentyFortyEight.Core/Game2048Engine.cs
+++ b/src/TwentyFortyEight.Core/Game2048Engine.cs
@@ -14,6 +14,9 @@ public class Game2048Engine
     private int _currentMoveIndex;
     private GameState _initialState;
 
+    private int _pendingExternalSpawnIndex = -1;
+    private int _pendingExternalSpawnValue;
+
     private GameState _currentState;
 
     /// <summary>
@@ -154,6 +157,9 @@ public class Game2048Engine
         _currentMoveIndex = 0;
         _currentState = new GameState(_config.Size);
 
+        _pendingExternalSpawnIndex = -1;
+        _pendingExternalSpawnValue = 0;
+
         // Start with two random tiles
         SpawnTileWithInfo();
         SpawnTileWithInfo();
@@ -170,6 +176,17 @@ public class Game2048Engine
     /// </summary>
     public bool Move(Direction direction)
     {
+        // In Adversarial mode, moves are made by the AI after a player-controlled spawn.
+        // If no player spawn is pending, treat Move as a no-op.
+        if (_config.Mode == GameMode.Adversarial && _pendingExternalSpawnIndex < 0)
+        {
+            if (!_currentState.IsGameOver && IsGameOver())
+            {
+                FinalizeAdversarialPlayerWinByLockingAi();
+            }
+            return false;
+        }
+
         var playfield = new PlayfieldSnapshot(_currentState.Board, _currentState.Wall);
         var (newBoard, scoreIncrease, boardChanged, maxMergedValue) = _boardSimulator.SimulateMove(
             new BoardMoveRequest(playfield, direction)
@@ -180,9 +197,30 @@ public class Game2048Engine
             // Check if game is over (no moves possible in any direction)
             if (!_currentState.IsGameOver && IsGameOver())
             {
-                _currentState = _currentState.WithUpdate(isGameOver: true);
-                _statisticsTracker.OnGameEnded(_currentState.Score, _currentState.IsWon);
+                if (_config.Mode == GameMode.Adversarial)
+                {
+                    FinalizeAdversarialPlayerWinByLockingAi();
+                }
+                else
+                {
+                    _currentState = _currentState.WithUpdate(isGameOver: true);
+                    _statisticsTracker.OnGameEnded(_currentState.Score, _currentState.IsWon);
+                }
             }
+
+            // In Adversarial mode, we still want to record the player-controlled spawn as a
+            // committed turn so Undo works even when the AI has no valid moves.
+            if (_config.Mode == GameMode.Adversarial && _pendingExternalSpawnIndex >= 0)
+            {
+                RecordMove(
+                    direction,
+                    spawnedTileIndex: -1,
+                    spawnedTileValue: 0,
+                    wallAfterMove: null
+                );
+                return true;
+            }
+
             return false;
         }
 
@@ -193,18 +231,38 @@ public class Game2048Engine
         }
 
         // Update state - track the new max tile value
+        // Adversarial mode still uses the standard 2048 scoring rules (points increase on merges),
+        // but the objective is inverted (lower final score is better).
         var newScore = _currentState.Score + scoreIncrease;
         var newMoveCount = _currentState.MoveCount + 1;
         var newMaxTile = Math.Max(_currentState.MaxTileValue, maxMergedValue);
         var wasWonBefore = _currentState.IsWon;
-        var isWon = wasWonBefore || newMaxTile >= _config.WinTile;
+        var reachedWinTile = newMaxTile >= _config.WinTile;
+        var isWon =
+            _config.Mode == GameMode.Adversarial ? wasWonBefore : wasWonBefore || reachedWinTile;
 
-        _currentState = new GameState(newBoard, newScore, newMoveCount, isWon, false, newMaxTile);
+        // In Adversarial mode, reaching the win tile is a LOSS (AI reached 2048).
+        // End the game immediately.
+        var isGameOver = false;
+        if (_config.Mode == GameMode.Adversarial && reachedWinTile)
+        {
+            isGameOver = true;
+            isWon = false;
+        }
+
+        _currentState = new GameState(
+            newBoard,
+            newScore,
+            newMoveCount,
+            isWon,
+            isGameOver,
+            newMaxTile
+        );
 
         // Track statistics
         _statisticsTracker.OnMoveMade();
         _statisticsTracker.UpdateHighestTile(newMaxTile);
-        _statisticsTracker.UpdateBestScore(newScore);
+        _statisticsTracker.UpdateBestScore(_config.Mode, newScore);
 
         // Check if game was just won
         if (isWon && !wasWonBefore)
@@ -220,8 +278,13 @@ public class Game2048Engine
             }
         }
 
-        // Spawn a new tile and record it
-        var (spawnIndex, spawnValue) = SpawnTileWithInfo();
+        // Spawn a new tile and record it (non-adversarial modes)
+        int spawnIndex = -1;
+        int spawnValue = 0;
+        if (_config.Mode != GameMode.Adversarial)
+        {
+            (spawnIndex, spawnValue) = SpawnTileWithInfo();
+        }
 
         WallSegment? wallAfterMove = null;
         if (_config.Mode == GameMode.Walltastrophy)
@@ -230,18 +293,92 @@ public class Game2048Engine
             _currentState = _currentState.WithWall(wallAfterMove);
         }
 
-        MoveRecord moveRecord = new(direction, spawnIndex, spawnValue, wallAfterMove);
-
-        _moveHistory.Add(moveRecord);
-        _currentMoveIndex++;
+        RecordMove(direction, spawnIndex, spawnValue, wallAfterMove);
 
         // Check if game is over
-        if (IsGameOver())
+        if (!_currentState.IsGameOver && IsGameOver())
         {
-            _currentState = _currentState.WithUpdate(isGameOver: true);
+            if (_config.Mode == GameMode.Adversarial)
+            {
+                FinalizeAdversarialPlayerWinByLockingAi();
+            }
+            else
+            {
+                _currentState = _currentState.WithUpdate(isGameOver: true);
+                _statisticsTracker.OnGameEnded(_currentState.Score, _currentState.IsWon);
+            }
+        }
+
+        // If the AI reached the win tile (Adversarial loss), finalize stats now.
+        if (_currentState.IsGameOver && _config.Mode == GameMode.Adversarial && reachedWinTile)
+        {
             _statisticsTracker.OnGameEnded(_currentState.Score, _currentState.IsWon);
         }
 
+        return true;
+    }
+
+    private void FinalizeAdversarialPlayerWinByLockingAi()
+    {
+        // Winning in Adversarial mode ends the game.
+        // We also raise the victory event so the UI can show the victory overlay
+        // (instead of the generic game-over dialog).
+        _currentState = _currentState.WithUpdate(isGameOver: true, isWon: true);
+
+        _statisticsTracker.OnGameWon();
+
+        // Raise victory event once per game (even if Undo rewinds IsWon)
+        if (!_victoryEventRaised)
+        {
+            _victoryEventRaised = true;
+            VictoryAchieved?.Invoke(this, EventArgs.Empty);
+        }
+
+        _statisticsTracker.OnGameEnded(_currentState.Score, _currentState.IsWon);
+    }
+
+    /// <summary>
+    /// In Adversarial mode, the player places the next tile at a chosen empty cell.
+    /// This does not increment move count and is recorded on the next AI move for Undo.
+    /// </summary>
+    public bool TrySpawnExternalTile(Position position, out int spawnedValue)
+    {
+        spawnedValue = 0;
+
+        if (_config.Mode != GameMode.Adversarial)
+        {
+            return false;
+        }
+
+        if (_currentState.IsGameOver)
+        {
+            return false;
+        }
+
+        if (
+            (uint)position.Row >= (uint)_currentState.Size
+            || (uint)position.Column >= (uint)_currentState.Size
+        )
+        {
+            return false;
+        }
+
+        // Only allow one pending spawn per AI turn.
+        if (_pendingExternalSpawnIndex >= 0)
+        {
+            return false;
+        }
+
+        if (_currentState.Board[position.Row, position.Column] != 0)
+        {
+            return false;
+        }
+
+        spawnedValue = _spawnStrategy.GetSpawnValue(_currentState, _config);
+        _currentState = _currentState.WithTile(position.Row, position.Column, spawnedValue);
+
+        _pendingExternalSpawnIndex = _currentState.Board.GetIndex(position.Row, position.Column);
+        _pendingExternalSpawnValue = spawnedValue;
         return true;
     }
 
@@ -285,12 +422,30 @@ public class Game2048Engine
         // Check if game is over
         if (IsGameOver())
         {
-            _currentState = _currentState.WithUpdate(isGameOver: true);
+            if (
+                _config.Mode == GameMode.Adversarial
+                && _currentState.MaxTileValue < _config.WinTile
+            )
+            {
+                _currentState = _currentState.WithUpdate(isGameOver: true, isWon: true);
+            }
+            else
+            {
+                _currentState = _currentState.WithUpdate(isGameOver: true);
+            }
         }
     }
 
     private GameState ApplyRecordedMove(GameState state, MoveRecord move)
     {
+        // Apply any player-controlled spawn first (Adversarial).
+        if (move.ExternalSpawnedTileIndex >= 0)
+        {
+            var spawnRow = move.ExternalSpawnedTileIndex / state.Size;
+            var spawnCol = move.ExternalSpawnedTileIndex % state.Size;
+            state = state.WithTile(spawnRow, spawnCol, move.ExternalSpawnedTileValue);
+        }
+
         var playfield = new PlayfieldSnapshot(state.Board, state.Wall);
         var (newBoard, scoreIncrease, moved, maxMergedValue) = _boardSimulator.SimulateMove(
             new BoardMoveRequest(playfield, move.Direction)
@@ -298,15 +453,32 @@ public class Game2048Engine
 
         if (!moved)
         {
+            // No movement, but the external spawn may have still changed the board.
             return state;
         }
 
         var newScore = state.Score + scoreIncrease;
         var newMoveCount = state.MoveCount + 1;
         var newMaxTile = Math.Max(state.MaxTileValue, maxMergedValue);
-        var isWon = state.IsWon || newMaxTile >= _config.WinTile;
+        var reachedWinTile = newMaxTile >= _config.WinTile;
+        var isWon =
+            _config.Mode == GameMode.Adversarial ? state.IsWon : state.IsWon || reachedWinTile;
 
-        var updated = new GameState(newBoard, newScore, newMoveCount, isWon, false, newMaxTile);
+        var isGameOver = false;
+        if (_config.Mode == GameMode.Adversarial && reachedWinTile)
+        {
+            isGameOver = true;
+            isWon = false;
+        }
+
+        var updated = new GameState(
+            newBoard,
+            newScore,
+            newMoveCount,
+            isWon,
+            isGameOver,
+            newMaxTile
+        );
 
         if (move.SpawnedTileIndex >= 0)
         {
@@ -321,6 +493,32 @@ public class Game2048Engine
         }
 
         return updated;
+    }
+
+    private void RecordMove(
+        Direction direction,
+        int spawnedTileIndex,
+        int spawnedTileValue,
+        WallSegment? wallAfterMove
+    )
+    {
+        var externalIndex = _pendingExternalSpawnIndex;
+        var externalValue = _pendingExternalSpawnValue;
+
+        _pendingExternalSpawnIndex = -1;
+        _pendingExternalSpawnValue = 0;
+
+        MoveRecord moveRecord = new(
+            direction,
+            spawnedTileIndex,
+            spawnedTileValue,
+            wallAfterMove,
+            externalIndex,
+            externalValue
+        );
+
+        _moveHistory.Add(moveRecord);
+        _currentMoveIndex++;
     }
 
     private (int index, int value) SpawnTileWithInfo()

--- a/src/TwentyFortyEight.Core/GameConfig.cs
+++ b/src/TwentyFortyEight.Core/GameConfig.cs
@@ -74,6 +74,7 @@ public class GameConfig
             GameMode.Modern => "modern",
             GameMode.Classic => "classic",
             GameMode.Walltastrophy => "walltastrophy",
+            GameMode.Adversarial => "adversarial",
             _ => "classic",
         };
 }

--- a/src/TwentyFortyEight.Core/GameMode.cs
+++ b/src/TwentyFortyEight.Core/GameMode.cs
@@ -23,4 +23,11 @@ public enum GameMode
     /// New tiles are spawned using the modern/adaptive spawn strategy.
     /// </summary>
     Modern = 2,
+
+    /// <summary>
+    /// Adversarial ruleset: the player places tiles and an AI performs moves.
+    /// Objective is to prevent the AI from reaching the win tile.
+    /// Lower score is better.
+    /// </summary>
+    Adversarial = 3,
 }

--- a/src/TwentyFortyEight.Core/IStatisticsTracker.cs
+++ b/src/TwentyFortyEight.Core/IStatisticsTracker.cs
@@ -34,10 +34,11 @@ public interface IStatisticsTracker
     void OnGameEnded(int finalScore, bool wasWon);
 
     /// <summary>
-    /// Updates the best score if the new score is higher.
+    /// Updates the best score if the new score is better.
+    /// For most modes, higher is better; for Adversarial mode, lower is better.
     /// </summary>
     /// <param name="score">The score to check.</param>
-    void UpdateBestScore(int score);
+    void UpdateBestScore(GameMode mode, int score);
 
     /// <summary>
     /// Updates the highest tile if the new tile value is higher.

--- a/src/TwentyFortyEight.Core/MoveRecord.cs
+++ b/src/TwentyFortyEight.Core/MoveRecord.cs
@@ -7,9 +7,13 @@ namespace TwentyFortyEight.Core;
 /// <param name="SpawnedTileIndex">The flat index where a new tile was spawned, or -1 if none.</param>
 /// <param name="SpawnedTileValue">The value of the spawned tile (2 or 4).</param>
 /// <param name="WallAfterMove">The between-cell wall segment after this move (Walltastrophy), or null.</param>
+/// <param name="ExternalSpawnedTileIndex">The flat index where a player-controlled tile was spawned (Adversarial), or -1 if none.</param>
+/// <param name="ExternalSpawnedTileValue">The value of the player-controlled spawned tile (Adversarial), or 0 if none.</param>
 public record MoveRecord(
     Direction Direction,
     int SpawnedTileIndex = -1,
     int SpawnedTileValue = 0,
-    WallSegment? WallAfterMove = null
+    WallSegment? WallAfterMove = null,
+    int ExternalSpawnedTileIndex = -1,
+    int ExternalSpawnedTileValue = 0
 );

--- a/src/TwentyFortyEight.Core/SpawnStrategyFactory.cs
+++ b/src/TwentyFortyEight.Core/SpawnStrategyFactory.cs
@@ -10,6 +10,7 @@ internal sealed class SpawnStrategyFactory(
         return config.Mode switch
         {
             GameMode.Classic => classicSpawnStrategy,
+            GameMode.Adversarial => classicSpawnStrategy,
             _ => modernSpawnStrategy,
         };
     }

--- a/src/TwentyFortyEight.Core/StatisticsTracker.cs
+++ b/src/TwentyFortyEight.Core/StatisticsTracker.cs
@@ -129,15 +129,23 @@ public abstract class StatisticsTracker : IStatisticsTracker
     }
 
     /// <summary>
-    /// Updates the best score if the new score is higher.
+    /// Updates the best score if the new score is better.
+    /// For most modes, higher is better; for Adversarial mode, lower is better.
     /// </summary>
     /// <param name="score">The score to check.</param>
-    public void UpdateBestScore(int score)
+    public void UpdateBestScore(GameMode mode, int score)
     {
         lock (_lock)
         {
             var stats = Statistics;
-            if (score > stats.BestScore)
+
+            var shouldUpdate = mode switch
+            {
+                GameMode.Adversarial => stats.BestScore == 0 || score < stats.BestScore,
+                _ => score > stats.BestScore,
+            };
+
+            if (shouldUpdate)
             {
                 stats.BestScore = score;
                 Save(stats);

--- a/src/TwentyFortyEight.Maui/Behaviors/RippleBehavior.cs
+++ b/src/TwentyFortyEight.Maui/Behaviors/RippleBehavior.cs
@@ -1,5 +1,6 @@
 using SkiaSharp.Views.Maui.Controls;
 using TwentyFortyEight.Maui.Services;
+using TwentyFortyEight.ViewModels;
 
 namespace TwentyFortyEight.Maui.Behaviors;
 
@@ -137,6 +138,15 @@ public sealed class RippleBehavior : Behavior<View>
         if (_attachedElement is null)
             return;
 
+        // The ripple effect is purely decorative and can interfere with fast-tap gameplay.
+        // Disable it entirely in Adversarial mode (where rapid taps are expected).
+        if (IsAdversarialModeActive())
+        {
+            _lastPointerPressPoint = null;
+            _lastPointerPressTimeUtc = default;
+            return;
+        }
+
         // Don't allow ripple while gameplay input is blocked (e.g., victory cinematic/modal).
         if (_inputCoordinationService?.IsInputBlocked == true)
             return;
@@ -170,6 +180,9 @@ public sealed class RippleBehavior : Behavior<View>
     private async Task StartRippleAsync(Point originInElement)
     {
         if (_rippleService is null || _rippleOverlay is null || _attachedElement is null)
+            return;
+
+        if (IsAdversarialModeActive())
             return;
 
         // Re-check before starting in case state changed after pointer event.
@@ -248,5 +261,19 @@ public sealed class RippleBehavior : Behavior<View>
         {
             _rippleGate.Release();
         }
+    }
+
+    private bool IsAdversarialModeActive()
+    {
+        // The behavior is attached to the board container, which is normally bound to GameViewModel.
+        // Be defensive and check up the visual tree as well.
+        if (_attachedElement is null)
+            return false;
+
+        var bindingContext =
+            _attachedElement.BindingContext
+            ?? (_attachedElement.Parent as BindableObject)?.BindingContext;
+
+        return bindingContext is GameViewModel { IsAdversarialMode: true };
     }
 }

--- a/src/TwentyFortyEight.Maui/Components/ModeSelectionView.xaml
+++ b/src/TwentyFortyEight.Maui/Components/ModeSelectionView.xaml
@@ -19,18 +19,15 @@
                     Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}"
                     components:LiquidGlass.EffectType="Regular"
                     components:LiquidGlass.EnableShadowEffect="False"
-                    components:LiquidGlass.CornerRadius="22">
-                <FlexLayout Direction="Row"
-                        Wrap="Wrap"
-                        JustifyContent="SpaceEvenly"
-                        AlignContent="Start"
-                        AlignItems="Start"
-                        Padding="2">
+                    components:LiquidGlass.CornerRadius="22"
+                    Padding="4">
+                <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,*" RowSpacing="4" ColumnSpacing="4">
+                    <!-- Row 0: Modern, Classic -->
                     <Border x:Name="ModernTab"
+                            Grid.Row="0" Grid.Column="0"
                             StrokeThickness="0"
-                            StrokeShape="RoundRectangle 20"
-                            Padding="0"
-                        Margin="0,0,0,1">
+                            StrokeShape="RoundRectangle 18"
+                            Padding="0">
                         <Button x:Name="ModernTabButton"
                                 Text="{x:Static strings:AppStrings.ModernMode}"
                                 FontSize="15"
@@ -42,10 +39,10 @@
                     </Border>
 
                     <Border x:Name="ClassicTab"
+                            Grid.Row="0" Grid.Column="1"
                             StrokeThickness="0"
-                            StrokeShape="RoundRectangle 20"
-                            Padding="0"
-                        Margin="0,0,0,1">
+                            StrokeShape="RoundRectangle 18"
+                            Padding="0">
                         <Button x:Name="ClassicTabButton"
                                 Text="{x:Static strings:AppStrings.ClassicMode}"
                                 FontSize="15"
@@ -56,11 +53,12 @@
                                 Clicked="OnClassicModeClicked" />
                     </Border>
 
+                    <!-- Row 1: Walltastrophy, Adversarial -->
                     <Border x:Name="WalltastrophyTab"
+                            Grid.Row="1" Grid.Column="0"
                             StrokeThickness="0"
-                            StrokeShape="RoundRectangle 20"
-                            Padding="0"
-                        Margin="0,0,0,1">
+                            StrokeShape="RoundRectangle 18"
+                            Padding="0">
                         <Button x:Name="WalltastrophyTabButton"
                                 Text="{x:Static strings:AppStrings.WalltastrophyMode}"
                                 FontSize="15"
@@ -70,7 +68,22 @@
                                 Background="Transparent"
                                 Clicked="OnWalltastrophyModeClicked" />
                     </Border>
-                </FlexLayout>
+
+                    <Border x:Name="AdversarialTab"
+                            Grid.Row="1" Grid.Column="1"
+                            StrokeThickness="0"
+                            StrokeShape="RoundRectangle 18"
+                            Padding="0">
+                        <Button x:Name="AdversarialTabButton"
+                                Text="{x:Static strings:AppStrings.AdversarialMode}"
+                                FontSize="15"
+                                FontAttributes="Bold"
+                                Padding="8,6"
+                                LineBreakMode="NoWrap"
+                                Background="Transparent"
+                                Clicked="OnAdversarialModeClicked" />
+                    </Border>
+                </Grid>
             </Border>
 
             <!-- Mode Description Text -->

--- a/src/TwentyFortyEight.Maui/Components/ModeSelectionView.xaml.cs
+++ b/src/TwentyFortyEight.Maui/Components/ModeSelectionView.xaml.cs
@@ -198,6 +198,11 @@ public partial class ModeSelectionView : ContentView
         _viewModel.PendingGameMode = GameMode.Walltastrophy;
     }
 
+    private void OnAdversarialModeClicked(object? sender, EventArgs e)
+    {
+        _viewModel.PendingGameMode = GameMode.Adversarial;
+    }
+
     private void UpdateHelperText()
     {
         ModeDescriptionLabel.Text = _viewModel.PendingGameMode switch
@@ -205,6 +210,7 @@ public partial class ModeSelectionView : ContentView
             GameMode.Modern => AppStrings.ModernModeDescription,
             GameMode.Classic => AppStrings.ClassicModeDescription,
             GameMode.Walltastrophy => AppStrings.WalltastrophyModeDescription,
+            GameMode.Adversarial => AppStrings.AdversarialModeDescription,
             _ => AppStrings.ModernModeDescription,
         };
     }
@@ -215,6 +221,7 @@ public partial class ModeSelectionView : ContentView
         bool isModern = selectedMode == GameMode.Modern;
         bool isClassic = selectedMode == GameMode.Classic;
         bool isWalltastrophy = selectedMode == GameMode.Walltastrophy;
+        bool isAdversarial = selectedMode == GameMode.Adversarial;
 
         var selectedBackground = GetThemeColor("Gray200", "Gray600");
         var selectedTextColor = GetThemeColor("NativeTextPrimaryLight", "NativeTextPrimaryDark");
@@ -226,12 +233,14 @@ public partial class ModeSelectionView : ContentView
         ModernTab.Background = isModern ? selectedBackground : Colors.Transparent;
         ClassicTab.Background = isClassic ? selectedBackground : Colors.Transparent;
         WalltastrophyTab.Background = isWalltastrophy ? selectedBackground : Colors.Transparent;
+        AdversarialTab.Background = isAdversarial ? selectedBackground : Colors.Transparent;
 
         ModernTabButton.TextColor = isModern ? selectedTextColor : unselectedTextColor;
         ClassicTabButton.TextColor = isClassic ? selectedTextColor : unselectedTextColor;
         WalltastrophyTabButton.TextColor = isWalltastrophy
             ? selectedTextColor
             : unselectedTextColor;
+        AdversarialTabButton.TextColor = isAdversarial ? selectedTextColor : unselectedTextColor;
     }
 
     private void OnPlayClicked(object? sender, EventArgs e)

--- a/src/TwentyFortyEight.Maui/Components/VictoryModalOverlay.xaml
+++ b/src/TwentyFortyEight.Maui/Components/VictoryModalOverlay.xaml
@@ -41,7 +41,7 @@
                            HorizontalOptions="Center"
                            SemanticProperties.HeadingLevel="Level1" />
 
-                    <Label Text="{x:Static resx:AppStrings.VictorySubtitle}"
+                    <Label Text="{Binding VictorySubtitleText}"
                            FontSize="18"
                            TextColor="{AppThemeBinding Light={StaticResource NativeTextSecondaryLight}, Dark={StaticResource NativeTextSecondaryDark}}"
                            HorizontalOptions="Center" />
@@ -68,7 +68,13 @@
                         <Button x:Name="KeepPlayingButton"
                                 Text="{x:Static resx:AppStrings.KeepPlaying}"
                                 Command="{Binding KeepPlayingCommand}"
-                                SemanticProperties.Hint="{x:Static resx:AppStrings.KeepPlayingHint}" />
+                                SemanticProperties.Hint="{x:Static resx:AppStrings.KeepPlayingHint}">
+                            <Button.Triggers>
+                                <DataTrigger TargetType="Button" Binding="{Binding State.IsAdversarialMode}" Value="True">
+                                    <Setter Property="IsVisible" Value="False" />
+                                </DataTrigger>
+                            </Button.Triggers>
+                        </Button>
 
                         <Button x:Name="NewGameButton"
                                 Text="{x:Static resx:AppStrings.NewGame}"

--- a/src/TwentyFortyEight.Maui/MainPage.xaml.cs
+++ b/src/TwentyFortyEight.Maui/MainPage.xaml.cs
@@ -35,6 +35,7 @@ public partial class MainPage : ContentPage
     private readonly IToolbarIconService _toolbarIconService;
     private readonly Dictionary<TileViewModel, Border> _tileBorders = [];
     private readonly Dictionary<TileViewModel, Label> _tileLabels = [];
+    private readonly Dictionary<TileViewModel, Border> _emptyCells = [];
     private readonly StringBuilder _boardAccessibilityBuilder = new(capacity: 256);
     private EventHandler<AppThemeChangedEventArgs>? _themeChangedHandler;
     private CancellationTokenSource? _animationCts;
@@ -127,8 +128,10 @@ public partial class MainPage : ContentPage
         _inputCoordinationService.RegisterBehaviors(this);
         _inputCoordinationService.DirectionInputReceived += OnDirectionInputReceived;
 
-        // Set up gesture recognizers for swipe detection
-        _gestureRecognizerService.AttachSwipeRecognizers(RootLayout);
+        // Set up gesture recognizers for swipe detection.
+        // Adversarial mode uses tap-to-spawn; swipes/pans can interfere with taps (and can trigger
+        // long-running UIGestureRecognizer blocking warnings on iOS), so disable them there.
+        UpdateSwipeRecognizersForMode();
         _gestureRecognizerService.SwipePanUpdated += OnSwipePanUpdated;
 
         // Subscribe to bottom sheet dismissal to sync ViewModel state
@@ -148,17 +151,62 @@ public partial class MainPage : ContentPage
         bool showDirectionButtons;
         try
         {
-            showDirectionButtons = _accessibilitySettingsService.IsVoiceControlEnabled();
+            // In Adversarial mode, player taps to spawn tiles - directional buttons are not used.
+            if (_viewModel.IsAdversarialMode)
+            {
+                showDirectionButtons = false;
+            }
+            else
+            {
+                showDirectionButtons = _accessibilitySettingsService.IsVoiceControlEnabled();
+            }
         }
         catch
         {
             showDirectionButtons = false;
         }
 
-        MoveLeftContainer.IsVisible = showDirectionButtons;
-        MoveUpContainer.IsVisible = showDirectionButtons;
-        MoveDownContainer.IsVisible = showDirectionButtons;
-        MoveRightContainer.IsVisible = showDirectionButtons;
+        // Only update if changed to avoid unnecessary layout invalidations and property change events.
+        if (MoveLeftContainer.IsVisible != showDirectionButtons)
+        {
+            MoveLeftContainer.IsVisible = showDirectionButtons;
+            MoveUpContainer.IsVisible = showDirectionButtons;
+            MoveDownContainer.IsVisible = showDirectionButtons;
+            MoveRightContainer.IsVisible = showDirectionButtons;
+        }
+    }
+
+    private void UpdateTileCellsAccessibilityForMode()
+    {
+        bool isAdversarial = _viewModel.IsAdversarialMode;
+        foreach (var (tile, emptyCell) in _emptyCells)
+        {
+            UpdateTileCellAccessibility(emptyCell, tile, isAdversarial);
+        }
+    }
+
+    private static void UpdateTileCellAccessibility(
+        Border emptyCell,
+        TileViewModel tile,
+        bool isAdversarialMode
+    )
+    {
+        // In Adversarial mode, only EMPTY cells are tap targets for spawning tiles.
+        // Occupied cells should not be in the accessibility tree.
+        bool shouldBeAccessible = isAdversarialMode && tile.Value == 0;
+
+        if (shouldBeAccessible)
+        {
+            AutomationProperties.SetIsInAccessibleTree(emptyCell, true);
+            AutomationProperties.SetName(
+                emptyCell,
+                $"Spawn at row {tile.Row + 1}, column {tile.Column + 1}"
+            );
+        }
+        else
+        {
+            AutomationProperties.SetIsInAccessibleTree(emptyCell, false);
+        }
     }
 
     private void RebuildBoardGrid()
@@ -187,6 +235,7 @@ public partial class MainPage : ContentPage
         GameBoard.ColumnDefinitions.Clear();
         _tileBorders.Clear();
         _tileLabels.Clear();
+        _emptyCells.Clear();
         WallOverlayLayer.Children.Clear();
 
         CreateTiles();
@@ -229,6 +278,9 @@ public partial class MainPage : ContentPage
         _viewModel.PropertyChanged += OnViewModelPropertyChanged;
         _inputCoordinationService.DirectionInputReceived += OnDirectionInputReceived;
         _gestureRecognizerService.SwipePanUpdated += OnSwipePanUpdated;
+
+        // Ensure swipe recognizers match the active mode when returning to the page.
+        UpdateSwipeRecognizersForMode();
 
         // Keep Voice Control visibility in sync with OS state.
         // Re-subscribe to changes and immediately check current state to handle edge cases
@@ -275,10 +327,28 @@ public partial class MainPage : ContentPage
 
     private async void OnSwipePanUpdated(object? sender, SwipePanEventArgs e)
     {
+        if (_viewModel.IsAdversarialMode)
+        {
+            return;
+        }
+
         await _swipePreviewInteractionService.HandleSwipePanUpdatedAsync(
             e,
             BuildSwipePreviewContext()
         );
+    }
+
+    private void UpdateSwipeRecognizersForMode()
+    {
+        if (_viewModel.IsAdversarialMode)
+        {
+            _gestureRecognizerService.DetachSwipeRecognizers(RootLayout);
+            _swipePreviewInteractionService.Reset();
+        }
+        else
+        {
+            _gestureRecognizerService.AttachSwipeRecognizers(RootLayout);
+        }
     }
 
     private SwipePreviewUiContext BuildSwipePreviewContext()
@@ -382,6 +452,7 @@ public partial class MainPage : ContentPage
         for (int i = 0; i < _viewModel.Tiles.Count; i++)
         {
             var tile = _viewModel.Tiles[i];
+            var tileIndex = i; // Capture for closure
 
             Border emptyCell = new()
             {
@@ -395,10 +466,30 @@ public partial class MainPage : ContentPage
                 },
             };
 
-            // Tiles/cells are not actionable; keep them out of the accessibility tree to avoid
-            // Voice Control clutter and misleading tap targets. The board container exposes the
-            // full board state via SemanticProperties.Description.
-            AutomationProperties.SetIsInAccessibleTree(emptyCell, false);
+            // Tiles/cells are not actionable in standard modes; keep them out of the accessibility tree.
+            // In Adversarial mode, empty cells become tap targets for spawning tiles, so we make them accessible.
+            UpdateTileCellAccessibility(emptyCell, tile, _viewModel.IsAdversarialMode);
+
+            // Store reference for later accessibility updates when mode changes
+            _emptyCells[tile] = emptyCell;
+
+            // Add tap gesture for adversarial mode where player spawns tiles.
+            // Create a shared tap handler - we'll add it to both emptyCell and the visible border
+            // since the border sits on top and would otherwise block taps.
+            void HandleTileTap(object? s, TappedEventArgs e)
+            {
+                if (
+                    _viewModel.IsAdversarialMode
+                    && _viewModel.TapEmptyCellCommand.CanExecute(tileIndex)
+                )
+                {
+                    _viewModel.TapEmptyCellCommand.Execute(tileIndex);
+                }
+            }
+
+            TapGestureRecognizer emptyTapGesture = new();
+            emptyTapGesture.Tapped += HandleTileTap;
+            emptyCell.GestureRecognizers.Add(emptyTapGesture);
 
             var label = new Label
             {
@@ -469,6 +560,11 @@ public partial class MainPage : ContentPage
             BindScaledFontSize(label);
 
             border.BindingContext = tile;
+
+            // Add tap gesture to border as well since it overlays emptyCell
+            TapGestureRecognizer borderTapGesture = new();
+            borderTapGesture.Tapped += HandleTileTap;
+            border.GestureRecognizers.Add(borderTapGesture);
 
             Grid.SetRow(emptyCell, tile.Row);
             Grid.SetColumn(emptyCell, tile.Column);
@@ -581,6 +677,12 @@ public partial class MainPage : ContentPage
         {
             HandleCoachNudgeVisibilityChanged();
         }
+        else if (e.PropertyName == nameof(GameViewModel.IsAdversarialMode))
+        {
+            UpdateSwipeRecognizersForMode();
+            UpdateVoiceControlMoveButtonsVisibility();
+            UpdateTileCellsAccessibilityForMode();
+        }
     }
 
     private void UpdateWallOverlay(WallSegment? wall)
@@ -684,7 +786,11 @@ public partial class MainPage : ContentPage
         try
         {
             // Trigger victory through the VictoryViewModel (MVVM pattern)
-            _victoryViewModel.TriggerVictory(_viewModel.Score, undoCount: _viewModel.UndoCount);
+            _victoryViewModel.TriggerVictory(
+                _viewModel.Score,
+                undoCount: _viewModel.UndoCount,
+                isAdversarialMode: _viewModel.IsAdversarialMode
+            );
         }
         finally
         {
@@ -696,6 +802,12 @@ public partial class MainPage : ContentPage
     {
         UpdateWallOverlay(e.WallAfterMove);
         UpdateBoardAccessibilityDescription();
+
+        // In Adversarial mode, update which cells are accessible (only empty cells).
+        if (_viewModel.IsAdversarialMode)
+        {
+            UpdateTileCellsAccessibilityForMode();
+        }
 
         await _swipePreviewInteractionService.HandleTilesUpdatedAsync(
             e,

--- a/src/TwentyFortyEight.Maui/Resources/Strings/AppStrings.Designer.cs
+++ b/src/TwentyFortyEight.Maui/Resources/Strings/AppStrings.Designer.cs
@@ -836,6 +836,24 @@ namespace TwentyFortyEight.Maui.Resources.Strings {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Adversarial.
+        /// </summary>
+        internal static string AdversarialMode {
+            get {
+                return ResourceManager.GetString("AdversarialMode", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Block the AI from reaching 2048. Tap empty cells to spawn tiles — the AI moves after each spawn. Lower score wins!.
+        /// </summary>
+        internal static string AdversarialModeDescription {
+            get {
+                return ResourceManager.GetString("AdversarialModeDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to MODE.
         /// </summary>
         internal static string ModeSection {
@@ -1237,6 +1255,15 @@ namespace TwentyFortyEight.Maui.Resources.Strings {
         internal static string VictorySubtitle {
             get {
                 return ResourceManager.GetString("VictorySubtitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to You blocked 2048!.
+        /// </summary>
+        internal static string AdversarialVictorySubtitle {
+            get {
+                return ResourceManager.GetString("AdversarialVictorySubtitle", resourceCulture);
             }
         }
 

--- a/src/TwentyFortyEight.Maui/Resources/Strings/AppStrings.resx
+++ b/src/TwentyFortyEight.Maui/Resources/Strings/AppStrings.resx
@@ -103,6 +103,12 @@
   <data name="WalltastrophyModeDescription" xml:space="preserve">
     <value>Each successful move places a new wall between cells. The wall blocks movement and merges across it.</value>
   </data>
+  <data name="AdversarialMode" xml:space="preserve">
+    <value>Adversarial</value>
+  </data>
+  <data name="AdversarialModeDescription" xml:space="preserve">
+    <value>Block the AI from reaching 2048. Tap empty cells to spawn tiles — the AI moves after each spawn. Lower score wins!</value>
+  </data>
   <data name="ModeSection" xml:space="preserve">
     <value>MODE</value>
   </data>
@@ -123,6 +129,9 @@
   </data>
   <data name="VictorySubtitle" xml:space="preserve">
     <value>You reached 2048!</value>
+  </data>
+  <data name="AdversarialVictorySubtitle" xml:space="preserve">
+    <value>You blocked 2048!</value>
   </data>
   <data name="VictoryAnnouncement" xml:space="preserve">
     <value>Victory! You reached 2048!</value>

--- a/src/TwentyFortyEight.Maui/Services/MauiLocalizationService.cs
+++ b/src/TwentyFortyEight.Maui/Services/MauiLocalizationService.cs
@@ -79,4 +79,8 @@ public class MauiLocalizationService : ILocalizationService
     /// <inheritdoc />
     public string FormatUndoCount(int undoCount) =>
         string.Format(CultureInfo.CurrentCulture, AppStrings.UndosUsedFormat, undoCount);
+
+    /// <inheritdoc />
+    public string GetVictorySubtitle(bool isAdversarialMode) =>
+        isAdversarialMode ? AppStrings.AdversarialVictorySubtitle : AppStrings.VictorySubtitle;
 }

--- a/src/TwentyFortyEight.Maui/Services/PlatformAchievementIds.cs
+++ b/src/TwentyFortyEight.Maui/Services/PlatformAchievementIds.cs
@@ -13,6 +13,7 @@ public static class PlatformAchievementIds
     public static class iOS
     {
         // Classic (default) mode leaderboards
+        public const string Leaderboard_3x3 = "com.dappermagna.twentyfortyeight.highscores.3x3";
         public const string Leaderboard_4x4 = "com.dappermagna.twentyfortyeight.highscores.4x4";
         public const string Leaderboard_5x5 = "com.dappermagna.twentyfortyeight.highscores.5x5";
         public const string Leaderboard_6x6 = "com.dappermagna.twentyfortyeight.highscores.6x6";
@@ -20,6 +21,8 @@ public static class PlatformAchievementIds
         public const string Leaderboard_8x8 = "com.dappermagna.twentyfortyeight.highscores.8x8";
 
         // Modern mode leaderboards
+        public const string Leaderboard_Modern_3x3 =
+            "com.dappermagna.twentyfortyeight.highscores.modern.3x3";
         public const string Leaderboard_Modern_4x4 =
             "com.dappermagna.twentyfortyeight.highscores.modern.4x4";
         public const string Leaderboard_Modern_5x5 =
@@ -32,6 +35,8 @@ public static class PlatformAchievementIds
             "com.dappermagna.twentyfortyeight.highscores.modern.8x8";
 
         // Walltastrophy mode leaderboards
+        public const string Leaderboard_Walltastrophy_3x3 =
+            "com.dappermagna.twentyfortyeight.highscores.walltastrophy.3x3";
         public const string Leaderboard_Walltastrophy_4x4 =
             "com.dappermagna.twentyfortyeight.highscores.walltastrophy.4x4";
         public const string Leaderboard_Walltastrophy_5x5 =
@@ -42,6 +47,20 @@ public static class PlatformAchievementIds
             "com.dappermagna.twentyfortyeight.highscores.walltastrophy.7x7";
         public const string Leaderboard_Walltastrophy_8x8 =
             "com.dappermagna.twentyfortyeight.highscores.walltastrophy.8x8";
+
+        // Adversarial mode leaderboards (lower score = better)
+        public const string Leaderboard_Adversarial_3x3 =
+            "com.dappermagna.twentyfortyeight.highscores.adversarial.3x3";
+        public const string Leaderboard_Adversarial_4x4 =
+            "com.dappermagna.twentyfortyeight.highscores.adversarial.4x4";
+        public const string Leaderboard_Adversarial_5x5 =
+            "com.dappermagna.twentyfortyeight.highscores.adversarial.5x5";
+        public const string Leaderboard_Adversarial_6x6 =
+            "com.dappermagna.twentyfortyeight.highscores.adversarial.6x6";
+        public const string Leaderboard_Adversarial_7x7 =
+            "com.dappermagna.twentyfortyeight.highscores.adversarial.7x7";
+        public const string Leaderboard_Adversarial_8x8 =
+            "com.dappermagna.twentyfortyeight.highscores.adversarial.8x8";
 
         public static string? GetHighScoreLeaderboardId(TwentyFortyEight.Core.GameConfig config)
         {
@@ -55,6 +74,7 @@ public static class PlatformAchievementIds
             {
                 TwentyFortyEight.Core.GameMode.Modern => config.Size switch
                 {
+                    3 => Leaderboard_Modern_3x3,
                     4 => Leaderboard_Modern_4x4,
                     5 => Leaderboard_Modern_5x5,
                     6 => Leaderboard_Modern_6x6,
@@ -64,6 +84,7 @@ public static class PlatformAchievementIds
                 },
                 TwentyFortyEight.Core.GameMode.Walltastrophy => config.Size switch
                 {
+                    3 => Leaderboard_Walltastrophy_3x3,
                     4 => Leaderboard_Walltastrophy_4x4,
                     5 => Leaderboard_Walltastrophy_5x5,
                     6 => Leaderboard_Walltastrophy_6x6,
@@ -71,8 +92,19 @@ public static class PlatformAchievementIds
                     8 => Leaderboard_Walltastrophy_8x8,
                     _ => null,
                 },
+                TwentyFortyEight.Core.GameMode.Adversarial => config.Size switch
+                {
+                    3 => Leaderboard_Adversarial_3x3,
+                    4 => Leaderboard_Adversarial_4x4,
+                    5 => Leaderboard_Adversarial_5x5,
+                    6 => Leaderboard_Adversarial_6x6,
+                    7 => Leaderboard_Adversarial_7x7,
+                    8 => Leaderboard_Adversarial_8x8,
+                    _ => null,
+                },
                 _ => config.Size switch
                 {
+                    3 => Leaderboard_3x3,
                     4 => Leaderboard_4x4,
                     5 => Leaderboard_5x5,
                     6 => Leaderboard_6x6,

--- a/src/TwentyFortyEight.ViewModels/GameViewModel.cs
+++ b/src/TwentyFortyEight.ViewModels/GameViewModel.cs
@@ -33,6 +33,7 @@ public partial class GameViewModel : ObservableObject
     private readonly VictoryViewModel _victoryViewModel;
     private readonly ICoachNudgeService _coachNudgeService;
     private readonly ICoachSuggestionService _coachSuggestionService;
+    private readonly IMoveAdvisor _moveAdvisor;
     private Game2048Engine _engine;
 
     /// <summary>
@@ -112,6 +113,11 @@ public partial class GameViewModel : ObservableObject
     public GameMode GameMode => _config.Mode;
 
     /// <summary>
+    /// Gets whether the current game mode is Adversarial (player blocks AI).
+    /// </summary>
+    public bool IsAdversarialMode => _config.Mode == GameMode.Adversarial;
+
+    /// <summary>
     /// Gets the current between-cell wall segment (Walltastrophy), or null.
     /// </summary>
     public WallSegment? Wall => _engine.CurrentState.Wall;
@@ -173,11 +179,13 @@ public partial class GameViewModel : ObservableObject
         IUserFeedbackService feedbackService,
         VictoryViewModel victoryViewModel,
         ICoachNudgeService coachNudgeService,
-        ICoachSuggestionService coachSuggestionService
+        ICoachSuggestionService coachSuggestionService,
+        IMoveAdvisor moveAdvisor
     )
     {
         _logger = logger;
         _moveAnalyzer = moveAnalyzer;
+        _moveAdvisor = moveAdvisor;
         _boardSimulator = boardSimulator;
         _settingsService = settingsService;
         _statisticsTracker = statisticsTracker;
@@ -274,6 +282,105 @@ public partial class GameViewModel : ObservableObject
         else
         {
             ClearCoachSuggestion();
+        }
+    }
+
+    /// <summary>
+    /// In Adversarial mode, the player taps an empty cell to spawn a tile.
+    /// After spawning, the AI automatically executes a move.
+    /// </summary>
+    [RelayCommand]
+    private async Task TapEmptyCellAsync(int tileIndex)
+    {
+        if (!IsAdversarialMode)
+        {
+            return;
+        }
+
+        // Don't queue up rapid taps - if a move is in progress, ignore this tap
+        if (!await _moveLock.WaitAsync(0))
+        {
+            return;
+        }
+
+        try
+        {
+            if (_engine.CurrentState.IsGameOver)
+            {
+                return;
+            }
+
+            // Convert tile index to Position
+            int row = tileIndex / BoardSize;
+            int col = tileIndex % BoardSize;
+            var position = new Position(row, col);
+
+            // Try to spawn at tapped position
+            if (!_engine.TrySpawnExternalTile(position, out var spawnedValue))
+            {
+                return;
+            }
+
+            // Store previous state for animation
+            var previousBoard = _engine.CurrentState.Board.Clone();
+            var previousWall = _engine.CurrentState.Wall;
+
+            // Get AI's recommended move
+            var recommendation = _moveAdvisor.Recommend(
+                new MoveAdvisorRequest(
+                    new PlayfieldSnapshot(_engine.CurrentState.Board, _engine.CurrentState.Wall),
+                    _config
+                )
+            );
+
+            if (recommendation is not null)
+            {
+                // AI executes its best move
+                var moved = _engine.Move(recommendation.Value.Direction);
+
+                if (moved)
+                {
+                    _feedbackService.PerformMoveHaptic();
+                    UpdateUI(
+                        previousBoard,
+                        recommendation.Value.Direction,
+                        previousWall,
+                        skipSlideAnimation: false
+                    );
+                    MarkGameSaveDirty();
+
+                    // In adversarial mode, lower score is better (scores remain non-negative).
+                    // Don't treat BestScore == 0 as "no best score yet" - 0 would be the perfect score.
+                    // Only update if we've beaten a previously-set non-zero best, or this is our first completed game.
+                    bool isNewBest = BestScore > 0 && Score < BestScore;
+                    if (isNewBest)
+                    {
+                        BestScore = Score;
+                        _repository.UpdateBestScoreIfHigher(_config, Score);
+                    }
+
+                    await Task.Delay(GetInputBlockDuration());
+                    await _sessionCoordinator.OnMoveCompletedAsync(_engine.CurrentState);
+                    await _sessionCoordinator.OnScoreChangedAsync(Score, isNewBest, _config);
+                }
+                else
+                {
+                    // AI couldn't move - player wins!
+                    UpdateUI();
+                }
+            }
+            else
+            {
+                // No valid moves for AI - player wins!
+                // The engine will mark game over with IsWon=true
+                _engine.Move(Direction.Up); // Trigger game over check
+                UpdateUI();
+            }
+        }
+        finally
+        {
+            _moveLock.Release();
+            ScheduleGameSaveIfDirty();
         }
     }
 
@@ -529,6 +636,12 @@ public partial class GameViewModel : ObservableObject
             return;
         }
 
+        // In Adversarial mode, player cannot swipe - only tap empty cells
+        if (IsAdversarialMode)
+        {
+            return;
+        }
+
         await _moveLock.WaitAsync();
 
         try
@@ -748,9 +861,14 @@ public partial class GameViewModel : ObservableObject
             // Don't announce during initialization
             if (_isInitialized)
             {
-                _feedbackService.AnnounceGameOver(Score);
-                // Show game over dialog asynchronously (fire and forget)
-                _ = ShowGameOverDialogAsync();
+                // In Adversarial mode, a win should show the victory overlay, not the generic game-over dialog.
+                // Losses still use the game-over dialog.
+                if (!(_config.Mode == GameMode.Adversarial && state.IsWon))
+                {
+                    _feedbackService.AnnounceGameOver(Score);
+                    // Show game over dialog asynchronously (fire and forget)
+                    _ = ShowGameOverDialogAsync();
+                }
             }
         }
 
@@ -996,6 +1114,7 @@ public partial class GameViewModel : ObservableObject
             // Notify UI that BoardSize changed and refresh values.
             OnPropertyChanged(nameof(BoardSize));
             OnPropertyChanged(nameof(GameMode));
+            OnPropertyChanged(nameof(IsAdversarialMode));
             UpdateUI();
             BoardReset?.Invoke(this, EventArgs.Empty);
 

--- a/src/TwentyFortyEight.ViewModels/Models/VictoryState.cs
+++ b/src/TwentyFortyEight.ViewModels/Models/VictoryState.cs
@@ -40,6 +40,12 @@ public sealed partial class VictoryState : ObservableObject
     private int _undoCount;
 
     /// <summary>
+    /// Whether the victory was in Adversarial mode (blocking 2048 vs reaching 2048).
+    /// </summary>
+    [ObservableProperty]
+    private bool _isAdversarialMode;
+
+    /// <summary>
     /// Resets the victory state to its initial values.
     /// </summary>
     public void Reset()
@@ -48,6 +54,8 @@ public sealed partial class VictoryState : ObservableObject
         IsModalVisible = false;
         WinningValue = 0;
         Score = 0;
+        UndoCount = 0;
+        IsAdversarialMode = false;
         UndoCount = 0;
     }
 }

--- a/src/TwentyFortyEight.ViewModels/Services/GameStateRepository.cs
+++ b/src/TwentyFortyEight.ViewModels/Services/GameStateRepository.cs
@@ -213,6 +213,12 @@ internal sealed partial class GameStateRepository(
 
     public void UpdateBestScoreIfHigher(GameConfig config, int score)
     {
+        if (score < 0)
+        {
+            // Scores are expected to be non-negative.
+            return;
+        }
+
         var boardSize = config.Size;
         if (boardSize <= 0 || boardSize > GameConfig.MaxReasonableBoardSize)
         {
@@ -222,10 +228,21 @@ internal sealed partial class GameStateRepository(
         var rulesetId = config.RulesetId;
 
         var currentBest = EnsureBestScoreLoaded(config);
-        if (score <= currentBest)
+        if (config.Mode == GameMode.Adversarial && currentBest < 0)
         {
-            return;
+            // Defensive migration: older Adversarial builds used negative scores.
+            // Treat as unset so the next valid score becomes the baseline.
+            currentBest = 0;
         }
+
+        var shouldUpdate = config.Mode switch
+        {
+            GameMode.Adversarial => currentBest == 0 || score < currentBest,
+            _ => score > currentBest,
+        };
+
+        if (!shouldUpdate)
+            return;
 
         Task saveTask;
         CancellationTokenSource cts;

--- a/src/TwentyFortyEight.ViewModels/Services/IGameStateRepository.cs
+++ b/src/TwentyFortyEight.ViewModels/Services/IGameStateRepository.cs
@@ -39,6 +39,9 @@ public interface IGameStateRepository
     /// <summary>
     /// Updates the best score if the new score is higher.
     /// Implements debouncing internally to avoid storage thrashing.
+    ///
+    /// Note: In Adversarial mode, lower score is better, so this will update when the
+    /// new score is lower than the current best.
     /// </summary>
     /// <param name="config">The game configuration.</param>
     /// <param name="score">The new score to potentially save.</param>

--- a/src/TwentyFortyEight.ViewModels/Services/ILocalizationService.cs
+++ b/src/TwentyFortyEight.ViewModels/Services/ILocalizationService.cs
@@ -112,4 +112,11 @@ public interface ILocalizationService
     /// Gets the localized screen reader announcement for the Coach nudge.
     /// </summary>
     string CoachNudgeAnnouncement { get; }
+
+    /// <summary>
+    /// Gets the localized victory subtitle based on game mode.
+    /// </summary>
+    /// <param name="isAdversarialMode">True if the victory was in Adversarial mode.</param>
+    /// <returns>"You blocked 2048!" for Adversarial, "You reached 2048!" otherwise.</returns>
+    string GetVictorySubtitle(bool isAdversarialMode);
 }

--- a/src/TwentyFortyEight.ViewModels/VictoryViewModel.cs
+++ b/src/TwentyFortyEight.ViewModels/VictoryViewModel.cs
@@ -32,6 +32,12 @@ public sealed partial class VictoryViewModel(
     public string UndoCountDisplayText => localizationService.FormatUndoCount(State.UndoCount);
 
     /// <summary>
+    /// Gets the localized victory subtitle ("You reached 2048!" or "You blocked 2048!").
+    /// </summary>
+    public string VictorySubtitleText =>
+        localizationService.GetVictorySubtitle(State.IsAdversarialMode);
+
+    /// <summary>
     /// Event raised when the user chooses to keep playing after victory.
     /// </summary>
     public event EventHandler? KeepPlayingRequested;
@@ -64,16 +70,24 @@ public sealed partial class VictoryViewModel(
     /// <param name="score">Current score at time of victory.</param>
     /// <param name="winningValue">The winning tile value (e.g., 2048).</param>
     /// <param name="undoCount">The number of undos performed during the game.</param>
-    public void TriggerVictory(int score, int winningValue = 2048, int undoCount = 0)
+    /// <param name="isAdversarialMode">Whether this is an Adversarial mode victory.</param>
+    public void TriggerVictory(
+        int score,
+        int winningValue = 2048,
+        int undoCount = 0,
+        bool isAdversarialMode = false
+    )
     {
         State.Score = score;
         State.WinningValue = winningValue;
         State.UndoCount = undoCount;
+        State.IsAdversarialMode = isAdversarialMode;
         State.IsActive = true;
 
         // Notify that the formatted text properties have changed
         OnPropertyChanged(nameof(ScoreDisplayText));
         OnPropertyChanged(nameof(UndoCountDisplayText));
+        OnPropertyChanged(nameof(VictorySubtitleText));
 
         if (ShouldReduceMotion)
         {

--- a/test/TwentyFortyEight.Core.Tests/AdversarialModeTests.cs
+++ b/test/TwentyFortyEight.Core.Tests/AdversarialModeTests.cs
@@ -1,0 +1,298 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using TwentyFortyEight.Core;
+
+namespace TwentyFortyEight.Core.Tests;
+
+[TestClass]
+public class AdversarialModeTests
+{
+    [TestMethod]
+    public void TrySpawnExternalTile_EmptyPosition_SpawnsTile()
+    {
+        // Arrange
+        GameConfig config = new() { Size = 4, Mode = GameMode.Adversarial };
+        var board = new int[16];
+        board[0] = 2; // (0,0) has a tile
+        var state = TestHelpers.CreateGameState(board, 4);
+
+        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+        random.Setup(r => r.NextDouble()).Returns(0.0); // Will spawn a 2
+
+        Game2048Engine engine = new(
+            state,
+            config,
+            random.Object,
+            NullStatisticsTracker.Instance,
+            new BoardMoveSimulator(),
+            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+        );
+
+        // Act
+        var position = new Position(1, 1); // index 5
+        bool success = engine.TrySpawnExternalTile(position, out int spawnedValue);
+
+        // Assert
+        Assert.IsTrue(success);
+        Assert.AreEqual(2, spawnedValue);
+        Assert.AreEqual(2, engine.CurrentState.Board[5]);
+    }
+
+    [TestMethod]
+    public void TrySpawnExternalTile_OccupiedPosition_ReturnsFalse()
+    {
+        // Arrange
+        GameConfig config = new() { Size = 4, Mode = GameMode.Adversarial };
+        var board = new int[16];
+        board[0] = 2; // (0,0) has a tile
+        var state = TestHelpers.CreateGameState(board, 4);
+
+        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+
+        Game2048Engine engine = new(
+            state,
+            config,
+            random.Object,
+            NullStatisticsTracker.Instance,
+            new BoardMoveSimulator(),
+            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+        );
+
+        // Act
+        var position = new Position(0, 0); // Already occupied
+        bool success = engine.TrySpawnExternalTile(position, out int spawnedValue);
+
+        // Assert
+        Assert.IsFalse(success);
+        Assert.AreEqual(0, spawnedValue);
+    }
+
+    [TestMethod]
+    public void Move_InAdversarialMode_UsesStandardPositiveScore()
+    {
+        // Arrange
+        GameConfig config = new() { Size = 4, Mode = GameMode.Adversarial };
+        var board = new int[16];
+        board[0] = 2; // (0,0)
+        board[1] = 2; // (0,1) - will merge with (0,0) on move left
+        var state = TestHelpers.CreateGameState(board, 4);
+
+        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+        random.Setup(r => r.NextDouble()).Returns(0.0); // Spawn a 2
+
+        Game2048Engine engine = new(
+            state,
+            config,
+            random.Object,
+            NullStatisticsTracker.Instance,
+            new BoardMoveSimulator(),
+            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+        );
+
+        // In adversarial mode, must spawn first before AI can move
+        engine.TrySpawnExternalTile(new Position(2, 0), out _); // Spawn at a different position
+
+        // Act
+        engine.Move(Direction.Left);
+
+        // Assert - merge of two 2s gives 4 points
+        Assert.AreEqual(4, engine.CurrentState.Score);
+    }
+
+    [TestMethod]
+    public void Move_AdversarialMode_LockedBoardAfterMove_IsWin()
+    {
+        // Arrange - a board where after a move, no more moves are possible
+        GameConfig config = new() { Size = 2, Mode = GameMode.Adversarial };
+        // Board: [2, 2]  After move left: [4, 0]
+        //        [4, 4]                   [8, 0]
+        // Then the board has empty cells, so not locked.
+
+        // Let's create a board that after merging becomes locked:
+        // [2, 4] -> move left -> [2, 4] (no change, but we need to test locked state)
+        // [4, 2]                 [4, 2]
+        // Actually this board has no valid moves, so Move() returns false.
+
+        // Test: spawn a tile that fills the last empty cell, then try to move
+        // and verify that when all moves fail, the game shows IsWon.
+
+        // Simpler approach: test that when Move fails on locked board, IsWon is set
+        var board = new int[4] { 2, 4, 4, 2 };
+        var state = TestHelpers.CreateGameState(board, 2);
+
+        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+
+        Game2048Engine engine = new(
+            state,
+            config,
+            random.Object,
+            NullStatisticsTracker.Instance,
+            new BoardMoveSimulator(),
+            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+        );
+
+        // Act - attempt to move (should fail since no moves possible)
+        bool moved = engine.Move(Direction.Left);
+
+        // Assert
+        Assert.IsFalse(moved);
+        // The board was already locked - IsGameOver check happens after a successful move
+        // or needs to be triggered by external spawn. For this test, verify the IsGameOver helper.
+        // Note: The game won't mark IsWon just from a failed move; it happens when Move succeeds
+        // but then no further moves are possible.
+    }
+
+    [TestMethod]
+    public void Move_AdversarialMode_LockedBoard_PlayerWins_RaisesVictoryAchieved()
+    {
+        // Arrange - a fully locked board (no moves possible)
+        GameConfig config = new() { Size = 2, Mode = GameMode.Adversarial };
+        var board = new int[4] { 2, 4, 4, 2 };
+        var state = TestHelpers.CreateGameState(board, 2);
+
+        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+
+        Game2048Engine engine = new(
+            state,
+            config,
+            random.Object,
+            NullStatisticsTracker.Instance,
+            new BoardMoveSimulator(),
+            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+        );
+
+        var victoryEvents = 0;
+        engine.VictoryAchieved += (_, _) => victoryEvents++;
+
+        // Act - no pending external spawn; Move() should detect lock and finalize win
+        var moved = engine.Move(Direction.Left);
+
+        // Assert
+        Assert.IsFalse(moved);
+        Assert.IsTrue(engine.CurrentState.IsGameOver);
+        Assert.IsTrue(engine.CurrentState.IsWon);
+        Assert.AreEqual(1, victoryEvents);
+    }
+
+    [TestMethod]
+    public void Move_AdversarialMode_AIReaches2048_IsGameOver()
+    {
+        // Arrange - two 1024 tiles that will merge to 2048
+        GameConfig config = new()
+        {
+            Size = 4,
+            Mode = GameMode.Adversarial,
+            WinTile = 2048,
+        };
+        var board = new int[16];
+        board[0] = 1024; // (0,0)
+        board[1] = 1024; // (0,1) - will merge to 2048 on move left
+        var state = TestHelpers.CreateGameState(board, 4);
+
+        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+        random.Setup(r => r.NextDouble()).Returns(0.0); // Spawn a 2
+
+        Game2048Engine engine = new(
+            state,
+            config,
+            random.Object,
+            NullStatisticsTracker.Instance,
+            new BoardMoveSimulator(),
+            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+        );
+
+        // In adversarial mode, must spawn first before AI can move
+        engine.TrySpawnExternalTile(new Position(2, 0), out _);
+
+        // Act
+        engine.Move(Direction.Left);
+
+        // Assert - when AI reaches 2048 (through merge), player loses
+        Assert.IsTrue(engine.CurrentState.IsGameOver);
+        Assert.IsFalse(engine.CurrentState.IsWon);
+    }
+
+    [TestMethod]
+    public void Undo_AdversarialMode_RestoresStateBeforeTurn()
+    {
+        // Arrange
+        GameConfig config = new() { Size = 4, Mode = GameMode.Adversarial };
+        var board = new int[16];
+        board[0] = 2;
+        var state = TestHelpers.CreateGameState(board, 4);
+
+        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+        random.Setup(r => r.NextDouble()).Returns(0.0); // Spawn 2
+
+        Game2048Engine engine = new(
+            state,
+            config,
+            random.Object,
+            NullStatisticsTracker.Instance,
+            new BoardMoveSimulator(),
+            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+        );
+
+        // Capture initial state
+        var initialBoard = engine.CurrentState.Board.Clone();
+
+        // External spawn at position (1,1) = index 5
+        engine.TrySpawnExternalTile(new Position(1, 1), out _);
+
+        // Move after spawn
+        engine.Move(Direction.Left);
+
+        // Act - undo should restore state before the entire turn (spawn + move)
+        bool undone = engine.Undo();
+
+        // Assert
+        Assert.IsTrue(undone);
+        // Board should be back to initial state (no external spawn)
+        CollectionAssert.AreEqual(initialBoard.ToArray(), engine.CurrentState.Board.ToArray());
+    }
+
+    [TestMethod]
+    public void ExternalSpawn_RecordedInMoveRecord()
+    {
+        // Arrange
+        GameConfig config = new() { Size = 4, Mode = GameMode.Adversarial };
+        var board = new int[16];
+        board[0] = 2;
+        var state = TestHelpers.CreateGameState(board, 4);
+
+        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+        random.Setup(r => r.NextDouble()).Returns(0.0); // Spawn 2
+        random.Setup(r => r.Next(It.IsAny<int>())).Returns(14);
+
+        Game2048Engine engine = new(
+            state,
+            config,
+            random.Object,
+            NullStatisticsTracker.Instance,
+            new BoardMoveSimulator(),
+            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+        );
+
+        // External spawn at index 5 (row=1, col=1)
+        engine.TrySpawnExternalTile(new Position(1, 1), out _);
+
+        // Move
+        engine.Move(Direction.Left);
+
+        // Assert - the move record should have the external spawn info
+        var saveDto = engine.ToSaveDto();
+        var lastMove = saveDto.MoveHistory!.Last();
+        Assert.AreEqual(5, lastMove.ExternalSpawnedTileIndex);
+        Assert.AreEqual(2, lastMove.ExternalSpawnedTileValue);
+    }
+
+    [TestMethod]
+    public void GameConfig_Adversarial_HasCorrectModeId()
+    {
+        // Arrange
+        var config = new GameConfig { Size = 4, Mode = GameMode.Adversarial };
+
+        // Assert
+        StringAssert.Contains(config.RulesetId, "adversarial");
+    }
+}

--- a/test/TwentyFortyEight.Core.Tests/StatisticsTrackerTests.cs
+++ b/test/TwentyFortyEight.Core.Tests/StatisticsTrackerTests.cs
@@ -19,7 +19,7 @@ internal sealed class NullStatisticsTracker : IStatisticsTracker
 
     public void OnGameEnded(int finalScore, bool wasWon) { }
 
-    public void UpdateBestScore(int score) { }
+    public void UpdateBestScore(GameMode mode, int score) { }
 
     public void UpdateHighestTile(int tileValue) { }
 
@@ -171,19 +171,35 @@ public class StatisticsTrackerTests
     }
 
     [TestMethod]
-    public void UpdateBestScore_UpdatesOnlyWhenHigher()
+    public void UpdateBestScore_ClassicMode_UpdatesOnlyWhenHigher()
     {
         // Arrange
         InMemoryStatisticsTracker tracker = new();
 
         // Act
-        tracker.UpdateBestScore(500);
-        tracker.UpdateBestScore(300); // Lower, should not update
-        tracker.UpdateBestScore(800); // Higher, should update
+        tracker.UpdateBestScore(GameMode.Classic, 500);
+        tracker.UpdateBestScore(GameMode.Classic, 300); // Lower, should not update
+        tracker.UpdateBestScore(GameMode.Classic, 800); // Higher, should update
 
         // Assert
         var stats = tracker.GetStatistics();
         Assert.AreEqual(800, stats.BestScore);
+    }
+
+    [TestMethod]
+    public void UpdateBestScore_AdversarialMode_UpdatesOnlyWhenLower()
+    {
+        // Arrange
+        InMemoryStatisticsTracker tracker = new();
+
+        // Act
+        tracker.UpdateBestScore(GameMode.Adversarial, 500);
+        tracker.UpdateBestScore(GameMode.Adversarial, 800); // Higher (worse), should not update
+        tracker.UpdateBestScore(GameMode.Adversarial, 300); // Lower (better), should update
+
+        // Assert
+        var stats = tracker.GetStatistics();
+        Assert.AreEqual(300, stats.BestScore);
     }
 
     [TestMethod]
@@ -209,7 +225,7 @@ public class StatisticsTrackerTests
         InMemoryStatisticsTracker tracker = new();
         tracker.OnGameStarted();
         tracker.OnMoveMade();
-        tracker.UpdateBestScore(1000);
+        tracker.UpdateBestScore(GameMode.Classic, 1000);
         tracker.OnGameWon();
         tracker.OnGameEnded(1000, wasWon: true);
 
@@ -251,7 +267,7 @@ public class StatisticsTrackerTests
         // Act - perform operations that should trigger saves
         tracker.OnGameStarted(); // Should save (1)
         tracker.OnGameWon(); // Should save (2)
-        tracker.UpdateBestScore(100); // Should save (3)
+        tracker.UpdateBestScore(GameMode.Classic, 100); // Should save (3)
         tracker.OnGameEnded(100, true); // Should save (4)
 
         // Assert - at least 4 saves should have occurred

--- a/test/TwentyFortyEight.ViewModels.Tests/GameStateRepositoryTests.cs
+++ b/test/TwentyFortyEight.ViewModels.Tests/GameStateRepositoryTests.cs
@@ -117,4 +117,126 @@ public class GameStateRepositoryTests
         // Assert
         Assert.IsNull(loaded);
     }
+
+    [TestMethod]
+    public void UpdateBestScoreIfHigher_ClassicMode_UpdatesOnlyWhenHigher()
+    {
+        // Arrange
+        var preferences = new InMemoryPreferencesService();
+        var logger = new Mock<ILogger<GameStateRepository>>();
+        var repository = new GameStateRepository(preferences, logger.Object);
+        var config = new GameConfig { Size = 4, Mode = GameMode.Classic };
+
+        // Act & Assert - first score sets the baseline
+        repository.UpdateBestScoreIfHigher(config, 500);
+        Assert.AreEqual(500, repository.GetBestScore(config));
+
+        // Lower score should not update
+        repository.UpdateBestScoreIfHigher(config, 300);
+        Assert.AreEqual(500, repository.GetBestScore(config));
+
+        // Higher score should update
+        repository.UpdateBestScoreIfHigher(config, 800);
+        Assert.AreEqual(800, repository.GetBestScore(config));
+    }
+
+    [TestMethod]
+    public void UpdateBestScoreIfHigher_AdversarialMode_UpdatesOnlyWhenLower()
+    {
+        // Arrange
+        var preferences = new InMemoryPreferencesService();
+        var logger = new Mock<ILogger<GameStateRepository>>();
+        var repository = new GameStateRepository(preferences, logger.Object);
+        var config = new GameConfig { Size = 4, Mode = GameMode.Adversarial };
+
+        // Act & Assert - first score sets the baseline
+        repository.UpdateBestScoreIfHigher(config, 500);
+        Assert.AreEqual(500, repository.GetBestScore(config));
+
+        // Higher score (worse in Adversarial) should not update
+        repository.UpdateBestScoreIfHigher(config, 800);
+        Assert.AreEqual(500, repository.GetBestScore(config));
+
+        // Lower score (better in Adversarial) should update
+        repository.UpdateBestScoreIfHigher(config, 300);
+        Assert.AreEqual(300, repository.GetBestScore(config));
+    }
+
+    [TestMethod]
+    public void UpdateBestScoreIfHigher_AdversarialMode_ZeroScoreBeatsNonZero()
+    {
+        // Arrange
+        var preferences = new InMemoryPreferencesService();
+        var logger = new Mock<ILogger<GameStateRepository>>();
+        var repository = new GameStateRepository(preferences, logger.Object);
+        var config = new GameConfig { Size = 4, Mode = GameMode.Adversarial };
+
+        // Set initial score
+        repository.UpdateBestScoreIfHigher(config, 500);
+        Assert.AreEqual(500, repository.GetBestScore(config));
+
+        // Zero is the best possible score in Adversarial (AI made no merges)
+        repository.UpdateBestScoreIfHigher(config, 0);
+        Assert.AreEqual(0, repository.GetBestScore(config));
+    }
+
+    [TestMethod]
+    public void UpdateBestScoreIfHigher_AdversarialMode_FirstScoreSetsBaseline()
+    {
+        // Arrange
+        var preferences = new InMemoryPreferencesService();
+        var logger = new Mock<ILogger<GameStateRepository>>();
+        var repository = new GameStateRepository(preferences, logger.Object);
+        var config = new GameConfig { Size = 4, Mode = GameMode.Adversarial };
+
+        // Initial best score is 0 (unset)
+        Assert.AreEqual(0, repository.GetBestScore(config));
+
+        // First score should always be recorded (even if it's high)
+        repository.UpdateBestScoreIfHigher(config, 1000);
+        Assert.AreEqual(1000, repository.GetBestScore(config));
+    }
+
+    [TestMethod]
+    public void UpdateBestScoreIfHigher_NegativeScore_IsIgnored()
+    {
+        // Arrange
+        var preferences = new InMemoryPreferencesService();
+        var logger = new Mock<ILogger<GameStateRepository>>();
+        var repository = new GameStateRepository(preferences, logger.Object);
+        var config = new GameConfig { Size = 4, Mode = GameMode.Classic };
+
+        repository.UpdateBestScoreIfHigher(config, 500);
+
+        // Negative scores should be ignored
+        repository.UpdateBestScoreIfHigher(config, -100);
+        Assert.AreEqual(500, repository.GetBestScore(config));
+    }
+
+    [TestMethod]
+    public void UpdateBestScoreIfHigher_AdversarialMode_ZeroIsUnsetSentinel()
+    {
+        // Arrange
+        var preferences = new InMemoryPreferencesService();
+        var logger = new Mock<ILogger<GameStateRepository>>();
+        var repository = new GameStateRepository(preferences, logger.Object);
+        var config = new GameConfig { Size = 4, Mode = GameMode.Adversarial };
+
+        // Initial best score is 0 (unset sentinel)
+        Assert.AreEqual(0, repository.GetBestScore(config));
+
+        // First score should set the baseline
+        repository.UpdateBestScoreIfHigher(config, 500);
+        Assert.AreEqual(500, repository.GetBestScore(config));
+
+        // Zero is treated as unset, so if we somehow get to 0, it becomes "unset" again
+        // This is a limitation: we can't distinguish "never played" from "perfect score of 0"
+        // In practice, achieving exactly 0 is nearly impossible (game starts with 2 tiles)
+        repository.UpdateBestScoreIfHigher(config, 0);
+        Assert.AreEqual(0, repository.GetBestScore(config));
+
+        // When 0 (unset), any score is accepted as the new baseline
+        repository.UpdateBestScoreIfHigher(config, 50);
+        Assert.AreEqual(50, repository.GetBestScore(config));
+    }
 }

--- a/test/TwentyFortyEight.ViewModels.Tests/GameViewModelTests.cs
+++ b/test/TwentyFortyEight.ViewModels.Tests/GameViewModelTests.cs
@@ -121,7 +121,8 @@ public class GameViewModelTests
             _feedbackServiceMock.Object,
             _victoryViewModel,
             _coachNudgeServiceMock.Object,
-            _coachSuggestionServiceMock.Object
+            _coachSuggestionServiceMock.Object,
+            _moveAdvisorMock.Object
         );
     }
 

--- a/test/TwentyFortyEight.ViewModels.Tests/VictoryViewModelTests.cs
+++ b/test/TwentyFortyEight.ViewModels.Tests/VictoryViewModelTests.cs
@@ -21,6 +21,8 @@ public class VictoryViewModelTests
         _localizationMock
             .Setup(x => x.FormatScore(It.IsAny<int>()))
             .Returns((int score) => $"Score: {score}");
+        _localizationMock.Setup(x => x.GetVictorySubtitle(false)).Returns("You reached 2048!");
+        _localizationMock.Setup(x => x.GetVictorySubtitle(true)).Returns("You blocked 2048!");
         _viewModel = new VictoryViewModel(
             _accessibilitySettingsMock.Object,
             _userFeedbackMock.Object,
@@ -172,5 +174,92 @@ public class VictoryViewModelTests
         // Assert
         Assert.AreEqual("Score: 12345", _viewModel.ScoreDisplayText);
         _localizationMock.Verify(x => x.FormatScore(12345), Times.AtLeastOnce);
+    }
+
+    [TestMethod]
+    public void TriggerVictory_StandardMode_SetsIsAdversarialModeFalse()
+    {
+        // Arrange
+        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+
+        // Act
+        _viewModel.TriggerVictory(score: 2048, isAdversarialMode: false);
+
+        // Assert
+        Assert.IsFalse(_viewModel.State.IsAdversarialMode);
+    }
+
+    [TestMethod]
+    public void TriggerVictory_AdversarialMode_SetsIsAdversarialModeTrue()
+    {
+        // Arrange
+        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+
+        // Act
+        _viewModel.TriggerVictory(score: 100, isAdversarialMode: true);
+
+        // Assert
+        Assert.IsTrue(_viewModel.State.IsAdversarialMode);
+    }
+
+    [TestMethod]
+    public void VictorySubtitleText_StandardMode_ReturnsReachedSubtitle()
+    {
+        // Arrange
+        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+
+        // Act
+        _viewModel.TriggerVictory(score: 2048, isAdversarialMode: false);
+
+        // Assert
+        Assert.AreEqual("You reached 2048!", _viewModel.VictorySubtitleText);
+        _localizationMock.Verify(x => x.GetVictorySubtitle(false), Times.AtLeastOnce);
+    }
+
+    [TestMethod]
+    public void VictorySubtitleText_AdversarialMode_ReturnsBlockedSubtitle()
+    {
+        // Arrange
+        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+
+        // Act
+        _viewModel.TriggerVictory(score: 100, isAdversarialMode: true);
+
+        // Assert
+        Assert.AreEqual("You blocked 2048!", _viewModel.VictorySubtitleText);
+        _localizationMock.Verify(x => x.GetVictorySubtitle(true), Times.AtLeastOnce);
+    }
+
+    [TestMethod]
+    public void Reset_ClearsIsAdversarialMode()
+    {
+        // Arrange
+        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _viewModel.TriggerVictory(score: 100, isAdversarialMode: true);
+        Assert.IsTrue(_viewModel.State.IsAdversarialMode);
+
+        // Act
+        _viewModel.KeepPlayingCommand.Execute(null);
+
+        // Assert
+        Assert.IsFalse(_viewModel.State.IsAdversarialMode);
+    }
+
+    [TestMethod]
+    public void TriggerVictory_NotifiesVictorySubtitleTextChanged()
+    {
+        // Arrange
+        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        var propertyChangedEvents = new List<string>();
+        _viewModel.PropertyChanged += (_, e) => propertyChangedEvents.Add(e.PropertyName!);
+
+        // Act
+        _viewModel.TriggerVictory(score: 2048, isAdversarialMode: true);
+
+        // Assert
+        CollectionAssert.Contains(
+            propertyChangedEvents,
+            nameof(VictoryViewModel.VictorySubtitleText)
+        );
     }
 }


### PR DESCRIPTION


- Introduced Adversarial mode where players block AI from reaching 2048.
- Added localized strings for Adversarial mode and its descriptions.
- Implemented logic for spawning tiles and AI moves in Adversarial mode.
- Updated scoring system to reflect lower scores as better in Adversarial mode.
- Enhanced GameStateRepository to handle best scores for Adversarial mode.
- Added unit tests for Adversarial mode functionality, including spawning, moves, and victory conditions.
- Updated VictoryViewModel to reflect the new victory subtitle based on game mode.