### PR TITLE
Update packages and replace Moq with NSubstitute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.userosscache
 *.sln.docstates
 *.env
+.DS_Store
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,24 +6,24 @@
   <ItemGroup>
     <!-- MAUI Dependencies -->
     <PackageVersion Include="M.BindableProperty.Generator" Version="0.11.1" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.80" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />
     <!-- MVVM Dependencies -->
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <!-- High Performance -->
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
     <!-- Animation Dependencies -->
-    <PackageVersion Include="CommunityToolkit.Maui" Version="14.2.2" />
+    <PackageVersion Include="CommunityToolkit.Maui" Version="15.0.0" />
     <!-- Skia (cross-platform shader-capable rendering) -->
-    <PackageVersion Include="SkiaSharp" Version="4.150.1" />
-    <PackageVersion Include="SkiaSharp.Skottie" Version="4.150.1" />
-    <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="4.150.1" />
+    <PackageVersion Include="SkiaSharp" Version="4.151.1" />
+    <PackageVersion Include="SkiaSharp.Skottie" Version="4.151.1" />
+    <PackageVersion Include="SkiaSharp.Views.Maui.Controls" Version="4.151.1" />
     <!-- Testing Dependencies -->
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="Appium.WebDriver" Version="8.3.2" />
-    <PackageVersion Include="Selenium.WebDriver" Version="4.46.0" />
+    <PackageVersion Include="Selenium.WebDriver" Version="4.47.0" />
     <!-- Code Formatting -->
     <PackageVersion Include="CSharpier.MsBuild" Version="1.3.0" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "MSTest.Sdk": "4.3.2"
+    "MSTest.Sdk": "4.3.3"
   },
   "sdk": {
     "allowPrerelease": false

--- a/src/TwentyFortyEight.ViewModels/AGENTS.md
+++ b/src/TwentyFortyEight.ViewModels/AGENTS.md
@@ -24,23 +24,23 @@ The ViewModels in this library use dependency injection for all platform-specifi
 
 ### Writing Tests
 
-Use Moq to mock the service interfaces:
+Use NSubstitute to substitute the service interfaces:
 
 ```csharp
 [TestMethod]
 public void Constructor_InitializesTilesCollection()
 {
-    // Arrange - mock all dependencies
-    var loggerMock = new Mock<ILogger<GameViewModel>>();
-    var preferencesServiceMock = new Mock<IPreferencesService>();
-    var alertServiceMock = new Mock<IAlertService>();
-    // ... setup mocks
+    // Arrange - substitute all dependencies
+    var logger = Substitute.For<ILogger<GameViewModel>>();
+    var preferencesService = Substitute.For<IPreferencesService>();
+    var alertService = Substitute.For<IAlertService>();
+    // ... configure substitutes
 
     // Act
     var viewModel = new GameViewModel(
-        loggerMock.Object,
-        moveAnalyzerMock.Object,
-        // ... other mocks
+        logger,
+        moveAnalyzer,
+        // ... other substitutes
     );
 
     // Assert

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -20,7 +20,7 @@ dotnet test
 ## Test Framework
 
 - **MSTest SDK**: Tests use the MSTest.Sdk project style for simplified configuration
-- **Moq**: Available for mocking interfaces and dependencies
+- **NSubstitute**: Available for substituting interfaces and dependencies
 - **Parallel Execution**: Tests run in parallel at the method level with `[Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 0)]`
 
 ## SDK-Style Test Projects
@@ -34,7 +34,7 @@ New test projects should use the `MSTest.Sdk` project style for minimal configur
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
   </ItemGroup>
 
 </Project>
@@ -80,19 +80,19 @@ public void ExampleTest()
 }
 ```
 
-### Using Mocks
+### Using Substitutes
 
-Use `SystemRandomSource(seed)` for deterministic tests or `Mock<IRandomSource>` for precise control:
+Use `SystemRandomSource(seed)` for deterministic tests or NSubstitute for precise control:
 
 ```csharp
 // Seeded random for deterministic tests
 var random = new SystemRandomSource(42);
 Game2048Engine engine = new(config, random);
 
-// Or use Moq for precise control
-Mock<IRandomSource> randomMock = new();
-randomMock.Setup(r => r.Next(It.IsAny<int>())).Returns(0);
-randomMock.Setup(r => r.NextDouble()).Returns(0.5);
+// Or use NSubstitute for precise control
+IRandomSource randomSubstitute = Substitute.For<IRandomSource>();
+randomSubstitute.Next(Arg.Any<int>()).Returns(0);
+randomSubstitute.NextDouble().Returns(0.5);
 
-Game2048Engine engine = new(config, randomMock.Object);
+Game2048Engine substitutedEngine = new(config, randomSubstitute);
 ```

--- a/test/TwentyFortyEight.Core.Tests/AdaptiveSpawnTests.cs
+++ b/test/TwentyFortyEight.Core.Tests/AdaptiveSpawnTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 
 namespace TwentyFortyEight.Core.Tests;
 
@@ -90,9 +90,9 @@ public class AdaptiveSpawnTests
         GameConfig config = new() { Size = 4 };
 
         // Create a mock random that always returns 0.5 (should spawn common value)
-        Mock<IRandomSource> mockRandom = new();
-        mockRandom.Setup(r => r.NextDouble()).Returns(0.5); // 0.5 < 0.9, so common value
-        mockRandom.Setup(r => r.Next(It.IsAny<int>())).Returns(0); // Always pick first empty cell
+        IRandomSource mockRandom = Substitute.For<IRandomSource>();
+        mockRandom.NextDouble().Returns(0.5); // 0.5 < 0.9, so common value
+        mockRandom.Next(Arg.Any<int>()).Returns(0); // Always pick first empty cell
 
         // Create board with 2048 tile and empty space
         var data = new int[16];
@@ -105,10 +105,10 @@ public class AdaptiveSpawnTests
         Game2048Engine engine = new(
             state,
             config,
-            mockRandom.Object,
+            mockRandom,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(mockRandom.Object)
+            TestHelpers.CreateSpawnStrategyFactory(mockRandom)
         );
 
         // Act
@@ -137,9 +137,9 @@ public class AdaptiveSpawnTests
         GameConfig config = new() { Size = 4 };
 
         // Create a mock random that always returns 0.5 (should spawn common value = 2)
-        Mock<IRandomSource> mockRandom = new();
-        mockRandom.Setup(r => r.NextDouble()).Returns(0.5);
-        mockRandom.Setup(r => r.Next(It.IsAny<int>())).Returns(0);
+        IRandomSource mockRandom = Substitute.For<IRandomSource>();
+        mockRandom.NextDouble().Returns(0.5);
+        mockRandom.Next(Arg.Any<int>()).Returns(0);
 
         // Create board with low value tiles
         var data = new int[16];
@@ -151,10 +151,10 @@ public class AdaptiveSpawnTests
         Game2048Engine engine = new(
             state,
             config,
-            mockRandom.Object,
+            mockRandom,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(mockRandom.Object)
+            TestHelpers.CreateSpawnStrategyFactory(mockRandom)
         );
 
         // Act

--- a/test/TwentyFortyEight.Core.Tests/AdversarialModeTests.cs
+++ b/test/TwentyFortyEight.Core.Tests/AdversarialModeTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 
 namespace TwentyFortyEight.Core.Tests;
 
@@ -14,16 +14,16 @@ public class AdversarialModeTests
         board[0] = 2; // (0,0) has a tile
         var state = TestHelpers.CreateGameState(board, 4);
 
-        var random = new Mock<IRandomSource>(MockBehavior.Strict);
-        random.Setup(r => r.NextDouble()).Returns(0.0); // Will spawn a 2
+        IRandomSource random = Substitute.For<IRandomSource>();
+        random.NextDouble().Returns(0.0); // Will spawn a 2
 
         Game2048Engine engine = new(
             state,
             config,
-            random.Object,
+            random,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+            TestHelpers.CreateSpawnStrategyFactory(random)
         );
 
         // Act
@@ -34,6 +34,7 @@ public class AdversarialModeTests
         Assert.IsTrue(success);
         Assert.AreEqual(2, spawnedValue);
         Assert.AreEqual(2, engine.CurrentState.Board[5]);
+        random.DidNotReceive().Next(Arg.Any<int>());
     }
 
     [TestMethod]
@@ -45,15 +46,15 @@ public class AdversarialModeTests
         board[0] = 2; // (0,0) has a tile
         var state = TestHelpers.CreateGameState(board, 4);
 
-        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+        IRandomSource random = Substitute.For<IRandomSource>();
 
         Game2048Engine engine = new(
             state,
             config,
-            random.Object,
+            random,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+            TestHelpers.CreateSpawnStrategyFactory(random)
         );
 
         // Act
@@ -63,6 +64,8 @@ public class AdversarialModeTests
         // Assert
         Assert.IsFalse(success);
         Assert.AreEqual(0, spawnedValue);
+        random.DidNotReceive().Next(Arg.Any<int>());
+        random.DidNotReceive().NextDouble();
     }
 
     [TestMethod]
@@ -75,16 +78,16 @@ public class AdversarialModeTests
         board[1] = 2; // (0,1) - will merge with (0,0) on move left
         var state = TestHelpers.CreateGameState(board, 4);
 
-        var random = new Mock<IRandomSource>(MockBehavior.Strict);
-        random.Setup(r => r.NextDouble()).Returns(0.0); // Spawn a 2
+        IRandomSource random = Substitute.For<IRandomSource>();
+        random.NextDouble().Returns(0.0); // Spawn a 2
 
         Game2048Engine engine = new(
             state,
             config,
-            random.Object,
+            random,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+            TestHelpers.CreateSpawnStrategyFactory(random)
         );
 
         // In adversarial mode, must spawn first before AI can move
@@ -95,6 +98,7 @@ public class AdversarialModeTests
 
         // Assert - merge of two 2s gives 4 points
         Assert.AreEqual(4, engine.CurrentState.Score);
+        random.DidNotReceive().Next(Arg.Any<int>());
     }
 
     [TestMethod]
@@ -118,15 +122,15 @@ public class AdversarialModeTests
         var board = new int[4] { 2, 4, 4, 2 };
         var state = TestHelpers.CreateGameState(board, 2);
 
-        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+        IRandomSource random = Substitute.For<IRandomSource>();
 
         Game2048Engine engine = new(
             state,
             config,
-            random.Object,
+            random,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+            TestHelpers.CreateSpawnStrategyFactory(random)
         );
 
         // Act - attempt to move (should fail since no moves possible)
@@ -138,6 +142,8 @@ public class AdversarialModeTests
         // or needs to be triggered by external spawn. For this test, verify the IsGameOver helper.
         // Note: The game won't mark IsWon just from a failed move; it happens when Move succeeds
         // but then no further moves are possible.
+        random.DidNotReceive().Next(Arg.Any<int>());
+        random.DidNotReceive().NextDouble();
     }
 
     [TestMethod]
@@ -148,15 +154,15 @@ public class AdversarialModeTests
         var board = new int[4] { 2, 4, 4, 2 };
         var state = TestHelpers.CreateGameState(board, 2);
 
-        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+        IRandomSource random = Substitute.For<IRandomSource>();
 
         Game2048Engine engine = new(
             state,
             config,
-            random.Object,
+            random,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+            TestHelpers.CreateSpawnStrategyFactory(random)
         );
 
         var victoryEvents = 0;
@@ -170,6 +176,8 @@ public class AdversarialModeTests
         Assert.IsTrue(engine.CurrentState.IsGameOver);
         Assert.IsTrue(engine.CurrentState.IsWon);
         Assert.AreEqual(1, victoryEvents);
+        random.DidNotReceive().Next(Arg.Any<int>());
+        random.DidNotReceive().NextDouble();
     }
 
     [TestMethod]
@@ -187,16 +195,16 @@ public class AdversarialModeTests
         board[1] = 1024; // (0,1) - will merge to 2048 on move left
         var state = TestHelpers.CreateGameState(board, 4);
 
-        var random = new Mock<IRandomSource>(MockBehavior.Strict);
-        random.Setup(r => r.NextDouble()).Returns(0.0); // Spawn a 2
+        IRandomSource random = Substitute.For<IRandomSource>();
+        random.NextDouble().Returns(0.0); // Spawn a 2
 
         Game2048Engine engine = new(
             state,
             config,
-            random.Object,
+            random,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+            TestHelpers.CreateSpawnStrategyFactory(random)
         );
 
         // In adversarial mode, must spawn first before AI can move
@@ -208,6 +216,7 @@ public class AdversarialModeTests
         // Assert - when AI reaches 2048 (through merge), player loses
         Assert.IsTrue(engine.CurrentState.IsGameOver);
         Assert.IsFalse(engine.CurrentState.IsWon);
+        random.DidNotReceive().Next(Arg.Any<int>());
     }
 
     [TestMethod]
@@ -219,16 +228,16 @@ public class AdversarialModeTests
         board[0] = 2;
         var state = TestHelpers.CreateGameState(board, 4);
 
-        var random = new Mock<IRandomSource>(MockBehavior.Strict);
-        random.Setup(r => r.NextDouble()).Returns(0.0); // Spawn 2
+        IRandomSource random = Substitute.For<IRandomSource>();
+        random.NextDouble().Returns(0.0); // Spawn 2
 
         Game2048Engine engine = new(
             state,
             config,
-            random.Object,
+            random,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+            TestHelpers.CreateSpawnStrategyFactory(random)
         );
 
         // Capture initial state
@@ -247,6 +256,7 @@ public class AdversarialModeTests
         Assert.IsTrue(undone);
         // Board should be back to initial state (no external spawn)
         CollectionAssert.AreEqual(initialBoard.ToArray(), engine.CurrentState.Board.ToArray());
+        random.DidNotReceive().Next(Arg.Any<int>());
     }
 
     [TestMethod]
@@ -258,17 +268,17 @@ public class AdversarialModeTests
         board[0] = 2;
         var state = TestHelpers.CreateGameState(board, 4);
 
-        var random = new Mock<IRandomSource>(MockBehavior.Strict);
-        random.Setup(r => r.NextDouble()).Returns(0.0); // Spawn 2
-        random.Setup(r => r.Next(It.IsAny<int>())).Returns(14);
+        IRandomSource random = Substitute.For<IRandomSource>();
+        random.NextDouble().Returns(0.0); // Spawn 2
+        random.Next(Arg.Any<int>()).Returns(14);
 
         Game2048Engine engine = new(
             state,
             config,
-            random.Object,
+            random,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+            TestHelpers.CreateSpawnStrategyFactory(random)
         );
 
         // External spawn at index 5 (row=1, col=1)

--- a/test/TwentyFortyEight.Core.Tests/ClassicSpawnTests.cs
+++ b/test/TwentyFortyEight.Core.Tests/ClassicSpawnTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 
 namespace TwentyFortyEight.Core.Tests;
 
@@ -11,9 +11,9 @@ public class ClassicSpawnTests
         // Arrange
         GameConfig config = new() { Size = 4, Mode = GameMode.Classic };
 
-        Mock<IRandomSource> mockRandom = new();
-        mockRandom.Setup(r => r.NextDouble()).Returns(0.5); // common value
-        mockRandom.Setup(r => r.Next(It.IsAny<int>())).Returns(0); // first empty cell
+        IRandomSource mockRandom = Substitute.For<IRandomSource>();
+        mockRandom.NextDouble().Returns(0.5); // common value
+        mockRandom.Next(Arg.Any<int>()).Returns(0); // first empty cell
 
         // Create board with high max tile; classic spawn should still be 2/4.
         var data = new int[16];
@@ -24,10 +24,10 @@ public class ClassicSpawnTests
         Game2048Engine engine = new(
             state,
             config,
-            mockRandom.Object,
+            mockRandom,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(mockRandom.Object)
+            TestHelpers.CreateSpawnStrategyFactory(mockRandom)
         );
 
         // Act
@@ -47,9 +47,9 @@ public class ClassicSpawnTests
         // Arrange
         GameConfig config = new() { Size = 4, Mode = GameMode.Classic };
 
-        Mock<IRandomSource> mockRandom = new();
-        mockRandom.Setup(r => r.NextDouble()).Returns(0.95); // rare value
-        mockRandom.Setup(r => r.Next(It.IsAny<int>())).Returns(0); // first empty cell
+        IRandomSource mockRandom = Substitute.For<IRandomSource>();
+        mockRandom.NextDouble().Returns(0.95); // rare value
+        mockRandom.Next(Arg.Any<int>()).Returns(0); // first empty cell
 
         var data = new int[16];
         data[0] = 8;
@@ -59,10 +59,10 @@ public class ClassicSpawnTests
         Game2048Engine engine = new(
             state,
             config,
-            mockRandom.Object,
+            mockRandom,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(mockRandom.Object)
+            TestHelpers.CreateSpawnStrategyFactory(mockRandom)
         );
 
         // Act

--- a/test/TwentyFortyEight.Core.Tests/HeuristicMoveAdvisorTests.cs
+++ b/test/TwentyFortyEight.Core.Tests/HeuristicMoveAdvisorTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 
 namespace TwentyFortyEight.Core.Tests;
 
@@ -8,14 +8,14 @@ namespace TwentyFortyEight.Core.Tests;
 [TestClass]
 public class HeuristicMoveAdvisorTests
 {
-    private Mock<IBoardSimulator> _simulatorMock = null!;
+    private IBoardSimulator _simulatorMock = null!;
     private HeuristicMoveAdvisor _advisor = null!;
 
     [TestInitialize]
     public void Setup()
     {
-        _simulatorMock = new Mock<IBoardSimulator>();
-        _advisor = new HeuristicMoveAdvisor(_simulatorMock.Object);
+        _simulatorMock = Substitute.For<IBoardSimulator>();
+        _advisor = new HeuristicMoveAdvisor(_simulatorMock);
     }
 
     [TestMethod]
@@ -27,9 +27,7 @@ public class HeuristicMoveAdvisorTests
         var config = new GameConfig { Size = 2 };
 
         // All moves return no change (no tiles to move)
-        _simulatorMock
-            .Setup(s => s.SimulateMove(It.IsAny<BoardMoveRequest>()))
-            .Returns((board, 0, false, 0));
+        _simulatorMock.SimulateMove(Arg.Any<BoardMoveRequest>()).Returns((board, 0, false, 0));
 
         // Act
         var result = _advisor.Recommend(
@@ -50,8 +48,12 @@ public class HeuristicMoveAdvisorTests
 
         // Setup simulator to return no moves
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.IsAny<BoardMoveRequest>()))
-            .Returns((BoardMoveRequest r) => (r.Playfield.Board, 0, false, 0));
+            .SimulateMove(Arg.Any<BoardMoveRequest>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<BoardMoveRequest>();
+                return (request.Playfield.Board, 0, false, 0);
+            });
 
         // Act
         var result = _advisor.Recommend(
@@ -72,21 +74,19 @@ public class HeuristicMoveAdvisorTests
 
         // Only left move is valid (for this test scenario)
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Up)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Up))
             .Returns((board, 0, false, 0));
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Down)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Down))
             .Returns((board, 0, false, 0));
         _simulatorMock
-            .Setup(s =>
-                s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
-            )
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
             .Returns((board, 0, false, 0));
 
         int[] movedData = [2, 0, 0, 0];
         var movedBoard = new Board(movedData, 2);
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Left)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Left))
             .Returns((movedBoard, 0, true, 0));
 
         // Act
@@ -129,24 +129,22 @@ public class HeuristicMoveAdvisorTests
         int[] leftData = [4, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         var leftBoard = new Board(leftData, 4);
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Left)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Left))
             .Returns((leftBoard, 4, true, 4));
 
         // Up: Just shifts (no merge in this scenario)
         int[] upData = [2, 2, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         var upBoard = new Board(upData, 4);
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Up)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Up))
             .Returns((upBoard, 0, true, 0));
 
         // Right/Down: no move
         _simulatorMock
-            .Setup(s =>
-                s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
-            )
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
             .Returns((board, 0, false, 0));
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Down)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Down))
             .Returns((board, 0, false, 0));
 
         // Act
@@ -190,20 +188,18 @@ public class HeuristicMoveAdvisorTests
         int[] leftData = [4, 4, 8, 0, 4, 8, 16, 32, 8, 16, 32, 64, 16, 32, 64, 0];
         var leftBoard = new Board(leftData, 4);
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Left)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Left))
             .Returns((leftBoard, 4, true, 4));
 
         // Other directions: no move
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Up)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Up))
             .Returns((board, 0, false, 0));
         _simulatorMock
-            .Setup(s =>
-                s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
-            )
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
             .Returns((board, 0, false, 0));
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Down)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Down))
             .Returns((board, 0, false, 0));
 
         // Act
@@ -230,24 +226,22 @@ public class HeuristicMoveAdvisorTests
         int[] upData = [2, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         var upBoard = new Board(upData, 4);
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Up)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Up))
             .Returns((upBoard, 0, true, 0));
 
         // Left: Moves max to corner!
         int[] leftData = [128, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         var leftBoard = new Board(leftData, 4);
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Left)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Left))
             .Returns((leftBoard, 0, true, 0));
 
         // Other directions
         _simulatorMock
-            .Setup(s =>
-                s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
-            )
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
             .Returns((board, 0, false, 0));
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Down)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Down))
             .Returns((board, 0, false, 0));
 
         // Act
@@ -273,19 +267,17 @@ public class HeuristicMoveAdvisorTests
         int[] leftData = [2, 4, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         var leftBoard = new Board(leftData, 4);
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Left)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Left))
             .Returns((leftBoard, 0, true, 0));
 
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Up)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Up))
             .Returns((board, 0, false, 0));
         _simulatorMock
-            .Setup(s =>
-                s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
-            )
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
             .Returns((board, 0, false, 0));
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Down)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Down))
             .Returns((board, 0, false, 0));
 
         // Act: Call twice
@@ -315,39 +307,31 @@ public class HeuristicMoveAdvisorTests
         int[] movedData3x3 = [4, 0, 0, 0, 0, 0, 0, 0, 0];
         var movedBoard3x3 = new Board(movedData3x3, 3);
         _simulatorMock
-            .Setup(s =>
-                s.SimulateMove(
-                    It.Is<BoardMoveRequest>(r =>
-                        r.Playfield.Board == board3x3 && r.Direction == Direction.Left
-                    )
+            .SimulateMove(
+                Arg.Is<BoardMoveRequest>(r =>
+                    r.Playfield.Board == board3x3 && r.Direction == Direction.Left
                 )
             )
             .Returns((movedBoard3x3, 4, true, 4));
 
         _simulatorMock
-            .Setup(s =>
-                s.SimulateMove(
-                    It.Is<BoardMoveRequest>(r =>
-                        r.Playfield.Board == board3x3 && r.Direction == Direction.Up
-                    )
+            .SimulateMove(
+                Arg.Is<BoardMoveRequest>(r =>
+                    r.Playfield.Board == board3x3 && r.Direction == Direction.Up
                 )
             )
             .Returns((board3x3, 0, false, 0));
         _simulatorMock
-            .Setup(s =>
-                s.SimulateMove(
-                    It.Is<BoardMoveRequest>(r =>
-                        r.Playfield.Board == board3x3 && r.Direction == Direction.Right
-                    )
+            .SimulateMove(
+                Arg.Is<BoardMoveRequest>(r =>
+                    r.Playfield.Board == board3x3 && r.Direction == Direction.Right
                 )
             )
             .Returns((board3x3, 0, false, 0));
         _simulatorMock
-            .Setup(s =>
-                s.SimulateMove(
-                    It.Is<BoardMoveRequest>(r =>
-                        r.Playfield.Board == board3x3 && r.Direction == Direction.Down
-                    )
+            .SimulateMove(
+                Arg.Is<BoardMoveRequest>(r =>
+                    r.Playfield.Board == board3x3 && r.Direction == Direction.Down
                 )
             )
             .Returns((board3x3, 0, false, 0));
@@ -371,9 +355,7 @@ public class HeuristicMoveAdvisorTests
         var config = new GameConfig { Size = 2 };
 
         // All moves return no change
-        _simulatorMock
-            .Setup(s => s.SimulateMove(It.IsAny<BoardMoveRequest>()))
-            .Returns((board, 0, false, 0));
+        _simulatorMock.SimulateMove(Arg.Any<BoardMoveRequest>()).Returns((board, 0, false, 0));
 
         // Act
         var result = _advisor.Recommend(
@@ -395,19 +377,17 @@ public class HeuristicMoveAdvisorTests
         int[] movedData = [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         var movedBoard = new Board(movedData, 4);
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Left)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Left))
             .Returns((movedBoard, 0, true, 0));
 
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Up)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Up))
             .Returns((board, 0, false, 0));
         _simulatorMock
-            .Setup(s =>
-                s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
-            )
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
             .Returns((board, 0, false, 0));
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Down)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Down))
             .Returns((board, 0, false, 0));
 
         // Act
@@ -433,23 +413,21 @@ public class HeuristicMoveAdvisorTests
         int[] goodData = [4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         var goodBoard = new Board(goodData, 4);
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Left)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Left))
             .Returns((goodBoard, 8, true, 4));
 
         // Move that creates less space
         int[] okData = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0];
         var okBoard = new Board(okData, 4);
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Up)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Up))
             .Returns((okBoard, 0, true, 0));
 
         _simulatorMock
-            .Setup(s =>
-                s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
-            )
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Right))
             .Returns((board, 0, false, 0));
         _simulatorMock
-            .Setup(s => s.SimulateMove(It.Is<BoardMoveRequest>(r => r.Direction == Direction.Down)))
+            .SimulateMove(Arg.Is<BoardMoveRequest>(r => r.Direction == Direction.Down))
             .Returns((board, 0, false, 0));
 
         // Act

--- a/test/TwentyFortyEight.Core.Tests/TileAnimationTests.cs
+++ b/test/TwentyFortyEight.Core.Tests/TileAnimationTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 
 namespace TwentyFortyEight.Core.Tests;
 
@@ -10,27 +10,31 @@ public class AnimationDetectionTests
     {
         // Arrange
         GameConfig config = new();
-        Mock<IRandomSource> randomMock = new();
+        IRandomSource randomMock = Substitute.For<IRandomSource>();
 
         // Setup random to return predictable values
         randomMock
-            .SetupSequence(r => r.Next(It.IsAny<int>()))
-            .Returns(0) // First spawn position
-            .Returns(1) // Second spawn position
-            .Returns(5); // Third spawn position after move (position that will be empty)
+            .Next(Arg.Any<int>())
+            .Returns(
+                0, // First spawn position
+                1, // Second spawn position
+                5 // Third spawn position after move (position that will be empty)
+            );
 
         randomMock
-            .SetupSequence(r => r.NextDouble())
-            .Returns(0.5) // First spawn value (2)
-            .Returns(0.5) // Second spawn value (2)
-            .Returns(0.5); // Third spawn value (2) - new tile
+            .NextDouble()
+            .Returns(
+                0.5, // First spawn value (2)
+                0.5, // Second spawn value (2)
+                0.5 // Third spawn value (2) - new tile
+            );
 
         Game2048Engine engine = new(
             config,
-            randomMock.Object,
+            randomMock,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(randomMock.Object)
+            TestHelpers.CreateSpawnStrategyFactory(randomMock)
         );
         var initialBoardSnapshot = engine.CurrentState.Board.ToArray();
 
@@ -55,7 +59,7 @@ public class AnimationDetectionTests
     {
         // Arrange - Create a board with two 2's that can merge
         GameConfig config = new();
-        Mock<IRandomSource> randomMock = new();
+        IRandomSource randomMock = Substitute.For<IRandomSource>();
 
         // Create initial state with two 2's in the same row
         var initialBoard = new int[16];
@@ -66,15 +70,15 @@ public class AnimationDetectionTests
         Game2048Engine engine = new(
             initialState,
             config,
-            randomMock.Object,
+            randomMock,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(randomMock.Object)
+            TestHelpers.CreateSpawnStrategyFactory(randomMock)
         );
 
         // Setup random for the new tile spawn after merge
-        randomMock.Setup(r => r.Next(It.IsAny<int>())).Returns(2);
-        randomMock.Setup(r => r.NextDouble()).Returns(0.5);
+        randomMock.Next(Arg.Any<int>()).Returns(2);
+        randomMock.NextDouble().Returns(0.5);
 
         // Act
         var moved = engine.Move(Direction.Left);
@@ -95,7 +99,7 @@ public class AnimationDetectionTests
     {
         // Arrange - Create a board with a tile that needs to slide
         GameConfig config = new();
-        Mock<IRandomSource> randomMock = new();
+        IRandomSource randomMock = Substitute.For<IRandomSource>();
 
         // Create initial state with a single tile not at the edge
         var initialBoard = new int[16];
@@ -105,15 +109,15 @@ public class AnimationDetectionTests
         Game2048Engine engine = new(
             initialState,
             config,
-            randomMock.Object,
+            randomMock,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(randomMock.Object)
+            TestHelpers.CreateSpawnStrategyFactory(randomMock)
         );
 
         // Setup random for the new tile spawn after slide
-        randomMock.Setup(r => r.Next(It.IsAny<int>())).Returns(2);
-        randomMock.Setup(r => r.NextDouble()).Returns(0.5);
+        randomMock.Next(Arg.Any<int>()).Returns(2);
+        randomMock.NextDouble().Returns(0.5);
 
         // Act
         var moved = engine.Move(Direction.Left);
@@ -129,17 +133,17 @@ public class AnimationDetectionTests
     {
         // Arrange
         GameConfig config = new();
-        Mock<IRandomSource> randomMock = new();
+        IRandomSource randomMock = Substitute.For<IRandomSource>();
 
-        randomMock.Setup(r => r.Next(It.IsAny<int>())).Returns(0);
-        randomMock.Setup(r => r.NextDouble()).Returns(0.5);
+        randomMock.Next(Arg.Any<int>()).Returns(0);
+        randomMock.NextDouble().Returns(0.5);
 
         Game2048Engine engine = new(
             config,
-            randomMock.Object,
+            randomMock,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(randomMock.Object)
+            TestHelpers.CreateSpawnStrategyFactory(randomMock)
         );
 
         // Act & Assert for each direction

--- a/test/TwentyFortyEight.Core.Tests/TwentyFortyEight.Core.Tests.csproj
+++ b/test/TwentyFortyEight.Core.Tests/TwentyFortyEight.Core.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TwentyFortyEight.Core.Tests/WalltastrophyModeTests.cs
+++ b/test/TwentyFortyEight.Core.Tests/WalltastrophyModeTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 
 namespace TwentyFortyEight.Core.Tests;
 
@@ -21,25 +21,25 @@ public class WalltastrophyModeTests
         );
         var state = TestHelpers.CreateGameState(board, 4).WithWall(initialWall);
 
-        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+        IRandomSource random = Substitute.For<IRandomSource>();
         random
-            .SetupSequence(r => r.Next(It.IsAny<int>()))
-            // Spawn tile selection (count = 15)
-            .Returns(14)
-            // Wall placement after move
-            .Returns(1) // orientation = Vertical
-            .Returns(0) // divider
-            .Returns(0) // start
-            .Returns(0); // length => 1 + 0
-        random.SetupSequence(r => r.NextDouble()).Returns(0.0);
+            .Next(Arg.Any<int>())
+            .Returns(
+                14, // Spawn tile selection (count = 15)
+                1, // Wall orientation = Vertical
+                0, // divider
+                0, // start
+                0 // length => 1 + 0
+            );
+        random.NextDouble().Returns(0.0);
 
         Game2048Engine engine = new(
             state,
             config,
-            random.Object,
+            random,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+            TestHelpers.CreateSpawnStrategyFactory(random)
         );
 
         var moved = engine.Move(Direction.Left);
@@ -49,6 +49,8 @@ public class WalltastrophyModeTests
         // Wall at divider=1 splits row 0 into [0..1] and [2..3]. Tile from col 3 can only move to col 2.
         Assert.AreEqual(2, engine.CurrentState.Board[2]);
         Assert.AreEqual(0, engine.CurrentState.Board[0]);
+        random.Received(5).Next(Arg.Any<int>());
+        random.Received(1).NextDouble();
     }
 
     [TestMethod]
@@ -73,32 +75,30 @@ public class WalltastrophyModeTests
             length: 2
         );
 
-        var random = new Mock<IRandomSource>(MockBehavior.Strict);
+        IRandomSource random = Substitute.For<IRandomSource>();
         random
-            .SetupSequence(r => r.Next(It.IsAny<int>()))
-            // Move 1 spawn (count = 15)
-            .Returns(0)
-            // Move 1 wall
-            .Returns(0) // orientation = Horizontal
-            .Returns(1) // divider
-            .Returns(0) // start
-            .Returns(3) // length => 1 + 3 = 4
-            // Move 2 spawn (count = 15)
-            .Returns(14)
-            // Move 2 wall
-            .Returns(1) // orientation = Vertical
-            .Returns(0) // divider
-            .Returns(2) // start
-            .Returns(1); // length => 1 + 1 = 2
-        random.SetupSequence(r => r.NextDouble()).Returns(0.0).Returns(0.0);
+            .Next(Arg.Any<int>())
+            .Returns(
+                0, // Move 1 spawn (count = 15)
+                0, // Move 1 wall orientation = Horizontal
+                1, // divider
+                0, // start
+                3, // length => 1 + 3 = 4
+                14, // Move 2 spawn (count = 15)
+                1, // Move 2 wall orientation = Vertical
+                0, // divider
+                2, // start
+                1 // length => 1 + 1 = 2
+            );
+        random.NextDouble().Returns(0.0, 0.0);
 
         Game2048Engine engine = new(
             state,
             config,
-            random.Object,
+            random,
             NullStatisticsTracker.Instance,
             new BoardMoveSimulator(),
-            TestHelpers.CreateSpawnStrategyFactory(random.Object)
+            TestHelpers.CreateSpawnStrategyFactory(random)
         );
 
         Assert.IsTrue(engine.Move(Direction.Right));
@@ -112,5 +112,7 @@ public class WalltastrophyModeTests
 
         Assert.IsTrue(engine.Undo());
         Assert.IsNull(engine.CurrentState.Wall);
+        random.Received(10).Next(Arg.Any<int>());
+        random.Received(2).NextDouble();
     }
 }

--- a/test/TwentyFortyEight.ViewModels.Tests/GameStateRepositoryTests.cs
+++ b/test/TwentyFortyEight.ViewModels.Tests/GameStateRepositoryTests.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using TwentyFortyEight.Core;
 using TwentyFortyEight.ViewModels.Serialization;
 using TwentyFortyEight.ViewModels.Services;
@@ -64,7 +64,7 @@ public class GameStateRepositoryTests
     {
         // Arrange
         var preferences = new InMemoryPreferencesService();
-        var logger = new Mock<ILogger<GameStateRepository>>();
+        ILogger<GameStateRepository> logger = Substitute.For<ILogger<GameStateRepository>>();
 
         GameState legacyState = new(4);
         var dto = GameStateDto.FromGameState(legacyState);
@@ -73,7 +73,7 @@ public class GameStateRepositoryTests
         preferences.SetString("SavedGame", json);
         preferences.SetInt("BestScore", 1234);
 
-        var repository = new GameStateRepository(preferences, logger.Object);
+        var repository = new GameStateRepository(preferences, logger);
 
         var config4 = new GameConfig { Size = 4 };
         Assert.AreEqual(string.Empty, config4.RulesetId);
@@ -97,7 +97,7 @@ public class GameStateRepositoryTests
     {
         // Arrange
         var preferences = new InMemoryPreferencesService();
-        var logger = new Mock<ILogger<GameStateRepository>>();
+        ILogger<GameStateRepository> logger = Substitute.For<ILogger<GameStateRepository>>();
 
         GameState state4 = new(4);
         var dto = GameStateDto.FromGameState(state4);
@@ -108,7 +108,7 @@ public class GameStateRepositoryTests
         preferences.SetString($"SavedGame.{config5.RulesetId}", json);
         preferences.SetBool("Migration.RulesetScopedPersistenceV1Complete", true);
 
-        var repository = new GameStateRepository(preferences, logger.Object);
+        var repository = new GameStateRepository(preferences, logger);
 
         // Act
         var loaded = repository.LoadGame(config5);
@@ -122,8 +122,8 @@ public class GameStateRepositoryTests
     {
         // Arrange
         var preferences = new InMemoryPreferencesService();
-        var logger = new Mock<ILogger<GameStateRepository>>();
-        var repository = new GameStateRepository(preferences, logger.Object);
+        ILogger<GameStateRepository> logger = Substitute.For<ILogger<GameStateRepository>>();
+        var repository = new GameStateRepository(preferences, logger);
         var config = new GameConfig { Size = 4, Mode = GameMode.Classic };
 
         // Act & Assert - first score sets the baseline
@@ -144,8 +144,8 @@ public class GameStateRepositoryTests
     {
         // Arrange
         var preferences = new InMemoryPreferencesService();
-        var logger = new Mock<ILogger<GameStateRepository>>();
-        var repository = new GameStateRepository(preferences, logger.Object);
+        ILogger<GameStateRepository> logger = Substitute.For<ILogger<GameStateRepository>>();
+        var repository = new GameStateRepository(preferences, logger);
         var config = new GameConfig { Size = 4, Mode = GameMode.Adversarial };
 
         // Act & Assert - first score sets the baseline
@@ -166,8 +166,8 @@ public class GameStateRepositoryTests
     {
         // Arrange
         var preferences = new InMemoryPreferencesService();
-        var logger = new Mock<ILogger<GameStateRepository>>();
-        var repository = new GameStateRepository(preferences, logger.Object);
+        ILogger<GameStateRepository> logger = Substitute.For<ILogger<GameStateRepository>>();
+        var repository = new GameStateRepository(preferences, logger);
         var config = new GameConfig { Size = 4, Mode = GameMode.Adversarial };
 
         // Set initial score
@@ -184,8 +184,8 @@ public class GameStateRepositoryTests
     {
         // Arrange
         var preferences = new InMemoryPreferencesService();
-        var logger = new Mock<ILogger<GameStateRepository>>();
-        var repository = new GameStateRepository(preferences, logger.Object);
+        ILogger<GameStateRepository> logger = Substitute.For<ILogger<GameStateRepository>>();
+        var repository = new GameStateRepository(preferences, logger);
         var config = new GameConfig { Size = 4, Mode = GameMode.Adversarial };
 
         // Initial best score is 0 (unset)
@@ -201,8 +201,8 @@ public class GameStateRepositoryTests
     {
         // Arrange
         var preferences = new InMemoryPreferencesService();
-        var logger = new Mock<ILogger<GameStateRepository>>();
-        var repository = new GameStateRepository(preferences, logger.Object);
+        ILogger<GameStateRepository> logger = Substitute.For<ILogger<GameStateRepository>>();
+        var repository = new GameStateRepository(preferences, logger);
         var config = new GameConfig { Size = 4, Mode = GameMode.Classic };
 
         repository.UpdateBestScoreIfHigher(config, 500);
@@ -217,8 +217,8 @@ public class GameStateRepositoryTests
     {
         // Arrange
         var preferences = new InMemoryPreferencesService();
-        var logger = new Mock<ILogger<GameStateRepository>>();
-        var repository = new GameStateRepository(preferences, logger.Object);
+        ILogger<GameStateRepository> logger = Substitute.For<ILogger<GameStateRepository>>();
+        var repository = new GameStateRepository(preferences, logger);
         var config = new GameConfig { Size = 4, Mode = GameMode.Adversarial };
 
         // Initial best score is 0 (unset sentinel)

--- a/test/TwentyFortyEight.ViewModels.Tests/GameViewModelTests.cs
+++ b/test/TwentyFortyEight.ViewModels.Tests/GameViewModelTests.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using TwentyFortyEight.Core;
 using TwentyFortyEight.ViewModels.Services;
 
@@ -15,70 +15,67 @@ namespace TwentyFortyEight.ViewModels.Tests;
 [TestClass]
 public class GameViewModelTests
 {
-    private Mock<ILogger<GameViewModel>> _loggerMock = null!;
-    private Mock<IMoveAnalyzer> _moveAnalyzerMock = null!;
-    private Mock<IMoveAdvisor> _moveAdvisorMock = null!;
-    private Mock<ISettingsService> _settingsServiceMock = null!;
-    private Mock<IStatisticsTracker> _statisticsTrackerMock = null!;
-    private Mock<IRandomSource> _randomSourceMock = null!;
+    private ILogger<GameViewModel> _loggerMock = null!;
+    private IMoveAnalyzer _moveAnalyzerMock = null!;
+    private IMoveAdvisor _moveAdvisorMock = null!;
+    private ISettingsService _settingsServiceMock = null!;
+    private IStatisticsTracker _statisticsTrackerMock = null!;
+    private IRandomSource _randomSourceMock = null!;
     private IGame2048EngineFactory _engineFactory = null!;
-    private Mock<IGameStateRepository> _repositoryMock = null!;
-    private Mock<IGameSessionCoordinator> _sessionCoordinatorMock = null!;
-    private Mock<IUserFeedbackService> _feedbackServiceMock = null!;
+    private IGameStateRepository _repositoryMock = null!;
+    private IGameSessionCoordinator _sessionCoordinatorMock = null!;
+    private IUserFeedbackService _feedbackServiceMock = null!;
     private IBoardSimulator _boardSimulator = null!;
-    private Mock<ICoachNudgeService> _coachNudgeServiceMock = null!;
-    private Mock<ICoachSuggestionService> _coachSuggestionServiceMock = null!;
+    private ICoachNudgeService _coachNudgeServiceMock = null!;
+    private ICoachSuggestionService _coachSuggestionServiceMock = null!;
     private VictoryViewModel _victoryViewModel = null!;
     private IMessenger _messenger = null!;
 
     [TestInitialize]
     public void Setup()
     {
-        _loggerMock = new Mock<ILogger<GameViewModel>>();
-        _moveAnalyzerMock = new Mock<IMoveAnalyzer>();
-        _moveAdvisorMock = new Mock<IMoveAdvisor>();
-        _settingsServiceMock = new Mock<ISettingsService>();
-        _statisticsTrackerMock = new Mock<IStatisticsTracker>();
-        _randomSourceMock = new Mock<IRandomSource>();
-        _repositoryMock = new Mock<IGameStateRepository>();
-        _sessionCoordinatorMock = new Mock<IGameSessionCoordinator>();
-        _feedbackServiceMock = new Mock<IUserFeedbackService>();
-        _coachNudgeServiceMock = new Mock<ICoachNudgeService>();
-        _coachSuggestionServiceMock = new Mock<ICoachSuggestionService>();
+        _loggerMock = Substitute.For<ILogger<GameViewModel>>();
+        _moveAnalyzerMock = Substitute.For<IMoveAnalyzer>();
+        _moveAdvisorMock = Substitute.For<IMoveAdvisor>();
+        _settingsServiceMock = Substitute.For<ISettingsService>();
+        _statisticsTrackerMock = Substitute.For<IStatisticsTracker>();
+        _randomSourceMock = Substitute.For<IRandomSource>();
+        _repositoryMock = Substitute.For<IGameStateRepository>();
+        _sessionCoordinatorMock = Substitute.For<IGameSessionCoordinator>();
+        _feedbackServiceMock = Substitute.For<IUserFeedbackService>();
+        _coachNudgeServiceMock = Substitute.For<ICoachNudgeService>();
+        _coachSuggestionServiceMock = Substitute.For<ICoachSuggestionService>();
         _messenger = new WeakReferenceMessenger();
 
         // Create real VictoryViewModel instance for testing
-        var accessibilitySettingsMock = new Mock<IAccessibilitySettingsService>();
-        var victoryFeedbackMock = new Mock<IUserFeedbackService>();
-        var localizationMock = new Mock<ILocalizationService>();
-        localizationMock
-            .Setup(x => x.FormatScore(It.IsAny<int>()))
-            .Returns((int score) => $"{score}");
+        var accessibilitySettingsMock = Substitute.For<IAccessibilitySettingsService>();
+        var victoryFeedbackMock = Substitute.For<IUserFeedbackService>();
+        var localizationMock = Substitute.For<ILocalizationService>();
+        localizationMock.FormatScore(Arg.Any<int>()).Returns(callInfo => $"{callInfo.Arg<int>()}");
         _victoryViewModel = new VictoryViewModel(
-            accessibilitySettingsMock.Object,
-            victoryFeedbackMock.Object,
-            localizationMock.Object
+            accessibilitySettingsMock,
+            victoryFeedbackMock,
+            localizationMock
         );
 
         // Setup default behavior
-        _settingsServiceMock.SetupGet(s => s.HapticsEnabled).Returns(true);
-        _settingsServiceMock.SetupGet(s => s.CoachEnabled).Returns(false);
-        _settingsServiceMock.SetupGet(s => s.CoachNudgesEnabled).Returns(true);
-        _settingsServiceMock.SetupSet<bool>(s => s.CoachEnabled = It.IsAny<bool>());
-        _settingsServiceMock.Setup(s => s.LastActiveGameConfig).Returns(new GameConfig());
-        _repositoryMock.Setup(r => r.GetBestScore(It.IsAny<GameConfig>())).Returns(0);
-        _repositoryMock.Setup(r => r.LoadGame(It.IsAny<GameConfig>())).Returns((GameSave?)null);
-        _sessionCoordinatorMock.Setup(s => s.IsSocialGamingAvailable).Returns(false);
+        _settingsServiceMock.HapticsEnabled.Returns(true);
+        _settingsServiceMock.CoachEnabled.Returns(false);
+        _settingsServiceMock.CoachNudgesEnabled.Returns(true);
+        _settingsServiceMock.LastActiveGameConfig.Returns(new GameConfig());
+        _repositoryMock.GetBestScore(Arg.Any<GameConfig>()).Returns(0);
+        _repositoryMock.LoadGame(Arg.Any<GameConfig>()).Returns((GameSave?)null);
+        _sessionCoordinatorMock.IsSocialGamingAvailable.Returns(false);
 
         // Setup random source for deterministic tile spawning
-        _randomSourceMock.Setup(r => r.Next(It.IsAny<int>())).Returns(0);
-        _randomSourceMock.Setup(r => r.NextDouble()).Returns(0.5);
+        _randomSourceMock.Next(Arg.Any<int>()).Returns(0);
+        _randomSourceMock.NextDouble().Returns(0.5);
 
-        var spawnStrategyFactory = CreateSpawnStrategyFactory(_randomSourceMock.Object);
+        var spawnStrategyFactory = CreateSpawnStrategyFactory(_randomSourceMock);
 
         _engineFactory = new Game2048EngineFactory(
-            _randomSourceMock.Object,
-            _statisticsTrackerMock.Object,
+            _randomSourceMock,
+            _statisticsTrackerMock,
             new BoardMoveSimulator(),
             spawnStrategyFactory
         );
@@ -111,19 +108,19 @@ public class GameViewModelTests
     private GameViewModel CreateViewModel()
     {
         return new GameViewModel(
-            _loggerMock.Object,
-            _moveAnalyzerMock.Object,
+            _loggerMock,
+            _moveAnalyzerMock,
             _boardSimulator,
-            _settingsServiceMock.Object,
-            _statisticsTrackerMock.Object,
+            _settingsServiceMock,
+            _statisticsTrackerMock,
             _engineFactory,
-            _repositoryMock.Object,
-            _sessionCoordinatorMock.Object,
-            _feedbackServiceMock.Object,
+            _repositoryMock,
+            _sessionCoordinatorMock,
+            _feedbackServiceMock,
             _victoryViewModel,
-            _coachNudgeServiceMock.Object,
-            _coachSuggestionServiceMock.Object,
-            _moveAdvisorMock.Object,
+            _coachNudgeServiceMock,
+            _coachSuggestionServiceMock,
+            _moveAdvisorMock,
             _messenger
         );
     }
@@ -153,8 +150,8 @@ public class GameViewModelTests
     public async Task MoveCommand_WhenMoveAlreadyInProgress_QueuesSecondMove()
     {
         _moveAnalyzerMock
-            .Setup(m => m.Analyze(It.IsAny<MoveAnalysisRequest>()))
-            .Returns(() => new MoveAnalysisResult(boardSize: 4));
+            .Analyze(Arg.Any<MoveAnalysisRequest>())
+            .Returns(_ => new MoveAnalysisResult(boardSize: 4));
 
         var viewModel = CreateViewModel();
 
@@ -174,7 +171,7 @@ public class GameViewModelTests
     {
         // Arrange
         _coachSuggestionServiceMock
-            .Setup(s => s.GetSuggestion(It.IsAny<CoachSuggestionRequest>()))
+            .GetSuggestion(Arg.Any<CoachSuggestionRequest>())
             .Returns(new MoveRecommendation(Direction.Left, 123, MoveCoachReason.CreateSpace));
 
         var viewModel = CreateViewModel();
@@ -194,7 +191,7 @@ public class GameViewModelTests
     {
         // Arrange
         _coachSuggestionServiceMock
-            .Setup(s => s.GetSuggestion(It.IsAny<CoachSuggestionRequest>()))
+            .GetSuggestion(Arg.Any<CoachSuggestionRequest>())
             .Returns(new MoveRecommendation(Direction.Left, 123, MoveCoachReason.CreateSpace));
 
         var viewModel = CreateViewModel();
@@ -219,7 +216,7 @@ public class GameViewModelTests
         var viewModel = CreateViewModel();
 
         // Simulate the nudge being shown
-        _coachNudgeServiceMock.Setup(s => s.IsNudgeVisible).Returns(true);
+        _coachNudgeServiceMock.IsNudgeVisible.Returns(true);
 
         // Act
         viewModel.DismissCoachNudgeCommand.Execute(null);
@@ -227,7 +224,7 @@ public class GameViewModelTests
         // Assert
         Assert.IsFalse(viewModel.IsCoachNudgeVisible);
         Assert.IsFalse(viewModel.IsCoachEnabled);
-        _coachNudgeServiceMock.Verify(s => s.Dismiss(), Times.Once);
+        _coachNudgeServiceMock.Received(1).Dismiss();
     }
 
     [TestMethod]
@@ -244,9 +241,7 @@ public class GameViewModelTests
     public void Constructor_WhenLastActiveBoardSizeSet_RestoresMode()
     {
         // Arrange
-        _settingsServiceMock
-            .Setup(s => s.LastActiveGameConfig)
-            .Returns(new GameConfig { Size = 5 });
+        _settingsServiceMock.LastActiveGameConfig.Returns(new GameConfig { Size = 5 });
 
         // Act
         var viewModel = CreateViewModel();
@@ -254,11 +249,8 @@ public class GameViewModelTests
         // Assert
         Assert.AreEqual(5, viewModel.BoardSize);
         Assert.HasCount(25, viewModel.Tiles); // 5x5 board
-        _repositoryMock.Verify(
-            r => r.GetBestScore(It.Is<GameConfig>(c => c.Size == 5)),
-            Times.Once
-        );
-        _repositoryMock.Verify(r => r.LoadGame(It.Is<GameConfig>(c => c.Size == 5)), Times.Once);
+        _repositoryMock.Received(1).GetBestScore(Arg.Is<GameConfig>(c => c.Size == 5));
+        _repositoryMock.Received(1).LoadGame(Arg.Is<GameConfig>(c => c.Size == 5));
     }
 
     [TestMethod]
@@ -271,7 +263,7 @@ public class GameViewModelTests
         await viewModel.ShowHowToPlayCommand.ExecuteAsync(null);
 
         // Assert
-        _feedbackServiceMock.Verify(f => f.ShowHowToPlayAsync(), Times.Once);
+        await _feedbackServiceMock.Received(1).ShowHowToPlayAsync();
     }
 
     [TestMethod]
@@ -326,18 +318,17 @@ public class GameViewModelTests
         await viewModel.NewGameCommand.ExecuteAsync(null);
 
         // Assert - Should not show confirmation dialog
-        _feedbackServiceMock.Verify(f => f.ConfirmNewGameAsync(), Times.Never);
-        _repositoryMock.Verify(
-            r => r.SaveGame(It.Is<GameConfig>(c => c.Size == 4), It.IsAny<GameSave>()),
-            Times.Once
-        );
+        await _feedbackServiceMock.DidNotReceive().ConfirmNewGameAsync();
+        _repositoryMock
+            .Received(1)
+            .SaveGame(Arg.Is<GameConfig>(c => c.Size == 4), Arg.Any<GameSave>());
     }
 
     [TestMethod]
     public async Task NewGameAsync_WhenMovesGreaterThanZeroAndUserCancels_DoesNotStartNewGame()
     {
         // Arrange
-        _feedbackServiceMock.Setup(f => f.ConfirmNewGameAsync()).ReturnsAsync(false);
+        _feedbackServiceMock.ConfirmNewGameAsync().Returns(Task.FromResult(false));
         var viewModel = CreateViewModel();
         viewModel.Moves = 1;
 
@@ -345,18 +336,15 @@ public class GameViewModelTests
         await viewModel.NewGameCommand.ExecuteAsync(null);
 
         // Assert
-        _feedbackServiceMock.Verify(f => f.ConfirmNewGameAsync(), Times.Once);
-        _repositoryMock.Verify(
-            r => r.SaveGame(It.IsAny<GameConfig>(), It.IsAny<GameSave>()),
-            Times.Never
-        );
+        await _feedbackServiceMock.Received(1).ConfirmNewGameAsync();
+        _repositoryMock.DidNotReceive().SaveGame(Arg.Any<GameConfig>(), Arg.Any<GameSave>());
     }
 
     [TestMethod]
     public async Task NewGameAsync_WhenMovesGreaterThanZeroAndUserConfirms_StartsNewGame()
     {
         // Arrange
-        _feedbackServiceMock.Setup(f => f.ConfirmNewGameAsync()).ReturnsAsync(true);
+        _feedbackServiceMock.ConfirmNewGameAsync().Returns(Task.FromResult(true));
         var viewModel = CreateViewModel();
         viewModel.Moves = 1;
 
@@ -364,11 +352,10 @@ public class GameViewModelTests
         await viewModel.NewGameCommand.ExecuteAsync(null);
 
         // Assert
-        _feedbackServiceMock.Verify(f => f.ConfirmNewGameAsync(), Times.Once);
-        _repositoryMock.Verify(
-            r => r.SaveGame(It.Is<GameConfig>(c => c.Size == 4), It.IsAny<GameSave>()),
-            Times.Once
-        );
+        await _feedbackServiceMock.Received(1).ConfirmNewGameAsync();
+        _repositoryMock
+            .Received(1)
+            .SaveGame(Arg.Is<GameConfig>(c => c.Size == 4), Arg.Any<GameSave>());
     }
 
     [TestMethod]
@@ -426,9 +413,7 @@ public class GameViewModelTests
     {
         // Arrange
         var viewModel = CreateViewModel();
-        _repositoryMock
-            .Setup(r => r.FlushAsync(It.IsAny<GameConfig>()))
-            .Returns(Task.CompletedTask);
+        _repositoryMock.FlushAsync(Arg.Any<GameConfig>()).Returns(Task.CompletedTask);
 
         var oldRulesetId = new GameConfig { Size = 4, WinTile = 2048 }.RulesetId;
         var newRulesetId = new GameConfig { Size = 5, WinTile = 2048 }.RulesetId;
@@ -439,25 +424,15 @@ public class GameViewModelTests
         await viewModel.PlaySelectedModeCommand.ExecuteAsync(null);
 
         // Assert
-        _repositoryMock.Verify(
-            r =>
-                r.SaveGame(
-                    It.Is<GameConfig>(c => c.RulesetId == oldRulesetId),
-                    It.IsAny<GameSave>()
-                ),
-            Times.AtLeastOnce
-        );
+        _repositoryMock
+            .Received()
+            .SaveGame(Arg.Is<GameConfig>(c => c.RulesetId == oldRulesetId), Arg.Any<GameSave>());
 
-        _repositoryMock.Verify(
-            r =>
-                r.SaveGame(
-                    It.Is<GameConfig>(c => c.RulesetId == newRulesetId),
-                    It.IsAny<GameSave>()
-                ),
-            Times.AtLeastOnce
-        );
+        _repositoryMock
+            .Received()
+            .SaveGame(Arg.Is<GameConfig>(c => c.RulesetId == newRulesetId), Arg.Any<GameSave>());
 
-        _repositoryMock.Verify(r => r.ClearSavedGame(It.IsAny<GameConfig>()), Times.Never);
+        _repositoryMock.DidNotReceive().ClearSavedGame(Arg.Any<GameConfig>());
     }
 
     [TestMethod]
@@ -465,9 +440,7 @@ public class GameViewModelTests
     {
         // Arrange
         var viewModel = CreateViewModel();
-        _repositoryMock
-            .Setup(r => r.FlushAsync(It.IsAny<GameConfig>()))
-            .Returns(Task.CompletedTask);
+        _repositoryMock.FlushAsync(Arg.Any<GameConfig>()).Returns(Task.CompletedTask);
 
         var newRulesetId = new GameConfig { Size = 5, WinTile = 2048 }.RulesetId;
         viewModel.PendingBoardSize = 5;
@@ -476,10 +449,9 @@ public class GameViewModelTests
         await viewModel.StartNewSelectedModeCommand.ExecuteAsync(null);
 
         // Assert
-        _repositoryMock.Verify(
-            r => r.ClearSavedGame(It.Is<GameConfig>(c => c.RulesetId == newRulesetId)),
-            Times.Once
-        );
+        _repositoryMock
+            .Received(1)
+            .ClearSavedGame(Arg.Is<GameConfig>(c => c.RulesetId == newRulesetId));
     }
 
     [TestMethod]
@@ -525,7 +497,7 @@ public class GameViewModelTests
     public async Task MoveCommand_WhenThreeConsecutiveInvalidMovesAndCoachDisabled_ShowsCoachNudge()
     {
         // Arrange
-        _coachNudgeServiceMock.Setup(s => s.ShouldShowNudge()).Returns(true);
+        _coachNudgeServiceMock.ShouldShowNudge().Returns(true);
 
         var viewModel = CreateViewModel();
         Assert.IsFalse(viewModel.IsCoachEnabled);
@@ -537,16 +509,16 @@ public class GameViewModelTests
         await viewModel.MoveCommand.ExecuteAsync(Direction.Up);
 
         // Assert
-        _coachNudgeServiceMock.Verify(s => s.TrackInvalidMove(), Times.Exactly(3));
-        _coachNudgeServiceMock.Verify(s => s.ShouldShowNudge(), Times.Exactly(3));
+        _coachNudgeServiceMock.Received(3).TrackInvalidMove();
+        _coachNudgeServiceMock.Received(3).ShouldShowNudge();
     }
 
     [TestMethod]
     public async Task MoveCommand_WhenCoachNudgesDisabled_DoesNotShowCoachNudge()
     {
         // Arrange
-        _settingsServiceMock.Setup(s => s.CoachNudgesEnabled).Returns(false);
-        _coachNudgeServiceMock.Setup(s => s.ShouldShowNudge()).Returns(false);
+        _settingsServiceMock.CoachNudgesEnabled.Returns(false);
+        _coachNudgeServiceMock.ShouldShowNudge().Returns(false);
 
         var viewModel = CreateViewModel();
         Assert.IsFalse(viewModel.IsCoachEnabled);
@@ -558,7 +530,7 @@ public class GameViewModelTests
 
         // Assert
         Assert.IsFalse(viewModel.IsCoachNudgeVisible);
-        _feedbackServiceMock.Verify(f => f.AnnounceCoachNudge(), Times.Never);
+        _feedbackServiceMock.DidNotReceive().AnnounceCoachNudge();
     }
 
     [TestMethod]
@@ -566,9 +538,9 @@ public class GameViewModelTests
     {
         // Arrange
         _moveAdvisorMock
-            .Setup(a => a.Recommend(It.IsAny<MoveAdvisorRequest>()))
+            .Recommend(Arg.Any<MoveAdvisorRequest>())
             .Returns((MoveRecommendation?)null);
-        _coachNudgeServiceMock.Setup(s => s.ShouldShowNudge()).Returns(false);
+        _coachNudgeServiceMock.ShouldShowNudge().Returns(false);
 
         var viewModel = CreateViewModel();
 
@@ -590,7 +562,7 @@ public class GameViewModelTests
     {
         // Arrange
         _moveAdvisorMock
-            .Setup(a => a.Recommend(It.IsAny<MoveAdvisorRequest>()))
+            .Recommend(Arg.Any<MoveAdvisorRequest>())
             .Returns((MoveRecommendation?)null);
 
         var viewModel = CreateViewModel();
@@ -601,8 +573,8 @@ public class GameViewModelTests
         // Assert
         Assert.IsTrue(viewModel.IsCoachEnabled);
         Assert.IsFalse(viewModel.IsCoachNudgeVisible);
-        _settingsServiceMock.VerifySet(s => s.CoachEnabled = true, Times.AtLeastOnce);
-        _coachNudgeServiceMock.Verify(s => s.Dismiss(), Times.Once);
+        _settingsServiceMock.Received().CoachEnabled = true;
+        _coachNudgeServiceMock.Received(1).Dismiss();
     }
 
     private static void InvokePrivateEngineVictoryHandler(GameViewModel viewModel, EventArgs args)
@@ -620,7 +592,7 @@ public class GameViewModelTests
     public void UndoButtonVisible_DefaultsToTrue()
     {
         // Arrange
-        _settingsServiceMock.Setup(s => s.UndoButtonVisible).Returns(true);
+        _settingsServiceMock.UndoButtonVisible.Returns(true);
 
         // Act
         var viewModel = CreateViewModel();
@@ -633,7 +605,7 @@ public class GameViewModelTests
     public void UndoButtonVisible_UpdatesFromSettingsService()
     {
         // Arrange
-        _settingsServiceMock.Setup(s => s.UndoButtonVisible).Returns(false);
+        _settingsServiceMock.UndoButtonVisible.Returns(false);
 
         // Act
         var viewModel = CreateViewModel();
@@ -657,10 +629,8 @@ public class GameViewModelTests
     private GameViewModel CreateAdversarialViewModel(int initialBestScore = 0)
     {
         var adversarialConfig = new GameConfig { Mode = GameMode.Adversarial };
-        _settingsServiceMock.Setup(s => s.LastActiveGameConfig).Returns(adversarialConfig);
-        _repositoryMock
-            .Setup(r => r.GetBestScore(It.IsAny<GameConfig>()))
-            .Returns(initialBestScore);
+        _settingsServiceMock.LastActiveGameConfig.Returns(adversarialConfig);
+        _repositoryMock.GetBestScore(Arg.Any<GameConfig>()).Returns(initialBestScore);
 
         return CreateViewModel();
     }
@@ -681,10 +651,7 @@ public class GameViewModelTests
 
         // Assert - Best score should update since BestScore was 0 (first win)
         Assert.AreEqual(256, viewModel.BestScore);
-        _repositoryMock.Verify(
-            r => r.UpdateBestScoreIfHigher(It.IsAny<GameConfig>(), 256),
-            Times.Once
-        );
+        _repositoryMock.Received(1).UpdateBestScoreIfHigher(Arg.Any<GameConfig>(), 256);
     }
 
     [TestMethod]
@@ -703,10 +670,7 @@ public class GameViewModelTests
 
         // Assert - Best score should update since Score < BestScore
         Assert.AreEqual(200, viewModel.BestScore);
-        _repositoryMock.Verify(
-            r => r.UpdateBestScoreIfHigher(It.IsAny<GameConfig>(), 200),
-            Times.Once
-        );
+        _repositoryMock.Received(1).UpdateBestScoreIfHigher(Arg.Any<GameConfig>(), 200);
     }
 
     [TestMethod]
@@ -725,10 +689,9 @@ public class GameViewModelTests
 
         // Assert - Best score should NOT update since Score > BestScore
         Assert.AreEqual(100, viewModel.BestScore);
-        _repositoryMock.Verify(
-            r => r.UpdateBestScoreIfHigher(It.IsAny<GameConfig>(), It.IsAny<int>()),
-            Times.Never
-        );
+        _repositoryMock
+            .DidNotReceive()
+            .UpdateBestScoreIfHigher(Arg.Any<GameConfig>(), Arg.Any<int>());
     }
 
     [TestMethod]
@@ -747,17 +710,16 @@ public class GameViewModelTests
 
         // Assert - Best score should NOT update since Score == BestScore (not strictly better)
         Assert.AreEqual(150, viewModel.BestScore);
-        _repositoryMock.Verify(
-            r => r.UpdateBestScoreIfHigher(It.IsAny<GameConfig>(), It.IsAny<int>()),
-            Times.Never
-        );
+        _repositoryMock
+            .DidNotReceive()
+            .UpdateBestScoreIfHigher(Arg.Any<GameConfig>(), Arg.Any<int>());
     }
 
     [TestMethod]
     public void NonAdversarialMode_OnVictory_DoesNotUpdateBestScoreInVictoryHandler()
     {
         // Arrange - Normal mode (best score update happens in Move, not victory handler)
-        _repositoryMock.Setup(r => r.GetBestScore(It.IsAny<GameConfig>())).Returns(100);
+        _repositoryMock.GetBestScore(Arg.Any<GameConfig>()).Returns(100);
         var viewModel = CreateViewModel();
         Assert.IsFalse(viewModel.IsAdversarialMode);
 
@@ -774,10 +736,9 @@ public class GameViewModelTests
         // Assert - Victory handler should NOT update best score in non-adversarial mode
         // (best score is updated during Move() in non-adversarial mode)
         Assert.AreEqual(100, viewModel.BestScore);
-        _repositoryMock.Verify(
-            r => r.UpdateBestScoreIfHigher(It.IsAny<GameConfig>(), It.IsAny<int>()),
-            Times.Never
-        );
+        _repositoryMock
+            .DidNotReceive()
+            .UpdateBestScoreIfHigher(Arg.Any<GameConfig>(), Arg.Any<int>());
     }
 
     [TestMethod]
@@ -800,10 +761,9 @@ public class GameViewModelTests
         // Note: UpdateUI() in victory handler resets Score to engine score (0),
         // so we verify the repository call was made with 0 (the engine's score after UpdateUI)
         // This test verifies the adversarial code path is executed.
-        _repositoryMock.Verify(
-            r => r.UpdateBestScoreIfHigher(It.IsAny<GameConfig>(), It.IsAny<int>()),
-            Times.Once
-        );
+        _repositoryMock
+            .Received(1)
+            .UpdateBestScoreIfHigher(Arg.Any<GameConfig>(), Arg.Any<int>());
     }
 
     #endregion

--- a/test/TwentyFortyEight.ViewModels.Tests/SettingsViewModelTests.cs
+++ b/test/TwentyFortyEight.ViewModels.Tests/SettingsViewModelTests.cs
@@ -1,5 +1,5 @@
 using CommunityToolkit.Mvvm.Messaging;
-using Moq;
+using NSubstitute;
 using TwentyFortyEight.ViewModels.Messages;
 using TwentyFortyEight.ViewModels.Services;
 
@@ -12,14 +12,14 @@ namespace TwentyFortyEight.ViewModels.Tests;
 public class SettingsViewModelTests
 {
     private static SettingsViewModel CreateViewModel(
-        Mock<ISettingsService> settingsServiceMock,
-        Mock<IHapticService> hapticServiceMock,
+        ISettingsService settingsServiceMock,
+        IHapticService hapticServiceMock,
         IMessenger? messenger = null
     )
     {
         return new SettingsViewModel(
-            settingsServiceMock.Object,
-            hapticServiceMock.Object,
+            settingsServiceMock,
+            hapticServiceMock,
             messenger ?? new WeakReferenceMessenger()
         );
     }
@@ -28,11 +28,11 @@ public class SettingsViewModelTests
     public void Constructor_LoadsHapticsEnabledFromService()
     {
         // Arrange
-        Mock<ISettingsService> settingsServiceMock = new();
-        Mock<IHapticService> hapticServiceMock = new();
-        settingsServiceMock.Setup(s => s.HapticsEnabled).Returns(false);
-        settingsServiceMock.Setup(s => s.CoachEnabled).Returns(false);
-        hapticServiceMock.Setup(h => h.IsSupported).Returns(true);
+        ISettingsService settingsServiceMock = Substitute.For<ISettingsService>();
+        IHapticService hapticServiceMock = Substitute.For<IHapticService>();
+        settingsServiceMock.HapticsEnabled.Returns(false);
+        settingsServiceMock.CoachEnabled.Returns(false);
+        hapticServiceMock.IsSupported.Returns(true);
 
         // Act
         SettingsViewModel viewModel = CreateViewModel(settingsServiceMock, hapticServiceMock);
@@ -45,11 +45,11 @@ public class SettingsViewModelTests
     public void IsHapticsSupported_ReturnsValueFromHapticService()
     {
         // Arrange
-        Mock<ISettingsService> settingsServiceMock = new();
-        Mock<IHapticService> hapticServiceMock = new();
-        settingsServiceMock.Setup(s => s.HapticsEnabled).Returns(true);
-        settingsServiceMock.Setup(s => s.CoachEnabled).Returns(false);
-        hapticServiceMock.Setup(h => h.IsSupported).Returns(false);
+        ISettingsService settingsServiceMock = Substitute.For<ISettingsService>();
+        IHapticService hapticServiceMock = Substitute.For<IHapticService>();
+        settingsServiceMock.HapticsEnabled.Returns(true);
+        settingsServiceMock.CoachEnabled.Returns(false);
+        hapticServiceMock.IsSupported.Returns(false);
 
         // Act
         SettingsViewModel viewModel = CreateViewModel(settingsServiceMock, hapticServiceMock);
@@ -62,48 +62,48 @@ public class SettingsViewModelTests
     public void HapticsEnabled_WhenChanged_UpdatesService()
     {
         // Arrange
-        Mock<ISettingsService> settingsServiceMock = new();
-        Mock<IHapticService> hapticServiceMock = new();
-        settingsServiceMock.Setup(s => s.HapticsEnabled).Returns(true);
-        settingsServiceMock.Setup(s => s.CoachEnabled).Returns(false);
-        hapticServiceMock.Setup(h => h.IsSupported).Returns(true);
+        ISettingsService settingsServiceMock = Substitute.For<ISettingsService>();
+        IHapticService hapticServiceMock = Substitute.For<IHapticService>();
+        settingsServiceMock.HapticsEnabled.Returns(true);
+        settingsServiceMock.CoachEnabled.Returns(false);
+        hapticServiceMock.IsSupported.Returns(true);
         SettingsViewModel viewModel = CreateViewModel(settingsServiceMock, hapticServiceMock);
 
         // Act
         viewModel.HapticsEnabled = false;
 
         // Assert
-        settingsServiceMock.VerifySet(s => s.HapticsEnabled = false, Times.Once);
+        settingsServiceMock.Received(1).HapticsEnabled = false;
     }
 
     [TestMethod]
     public void CoachEnabled_WhenChanged_UpdatesService()
     {
         // Arrange
-        Mock<ISettingsService> settingsServiceMock = new();
-        Mock<IHapticService> hapticServiceMock = new();
-        settingsServiceMock.Setup(s => s.HapticsEnabled).Returns(true);
-        settingsServiceMock.Setup(s => s.CoachEnabled).Returns(false);
-        hapticServiceMock.Setup(h => h.IsSupported).Returns(true);
+        ISettingsService settingsServiceMock = Substitute.For<ISettingsService>();
+        IHapticService hapticServiceMock = Substitute.For<IHapticService>();
+        settingsServiceMock.HapticsEnabled.Returns(true);
+        settingsServiceMock.CoachEnabled.Returns(false);
+        hapticServiceMock.IsSupported.Returns(true);
         SettingsViewModel viewModel = CreateViewModel(settingsServiceMock, hapticServiceMock);
 
         // Act
         viewModel.CoachEnabled = true;
 
         // Assert
-        settingsServiceMock.VerifySet(s => s.CoachEnabled = true, Times.Once);
+        settingsServiceMock.Received(1).CoachEnabled = true;
     }
 
     [TestMethod]
     public void CoachNudgesEnabled_WhenChanged_SendsMessageAndUpdatesService()
     {
         // Arrange
-        Mock<ISettingsService> settingsServiceMock = new();
-        Mock<IHapticService> hapticServiceMock = new();
-        settingsServiceMock.Setup(s => s.HapticsEnabled).Returns(true);
-        settingsServiceMock.Setup(s => s.CoachEnabled).Returns(false);
-        settingsServiceMock.Setup(s => s.CoachNudgesEnabled).Returns(true);
-        hapticServiceMock.Setup(h => h.IsSupported).Returns(true);
+        ISettingsService settingsServiceMock = Substitute.For<ISettingsService>();
+        IHapticService hapticServiceMock = Substitute.For<IHapticService>();
+        settingsServiceMock.HapticsEnabled.Returns(true);
+        settingsServiceMock.CoachEnabled.Returns(false);
+        settingsServiceMock.CoachNudgesEnabled.Returns(true);
+        hapticServiceMock.IsSupported.Returns(true);
 
         var messenger = new WeakReferenceMessenger();
         SettingsViewModel viewModel = CreateViewModel(
@@ -123,7 +123,7 @@ public class SettingsViewModelTests
         viewModel.CoachNudgesEnabled = false;
 
         // Assert
-        settingsServiceMock.VerifySet(s => s.CoachNudgesEnabled = false, Times.Once);
+        settingsServiceMock.Received(1).CoachNudgesEnabled = false;
         Assert.IsNotNull(receivedValue);
         Assert.IsFalse(receivedValue.Value);
 
@@ -134,12 +134,12 @@ public class SettingsViewModelTests
     public void Constructor_LoadsUndoButtonVisibleFromService()
     {
         // Arrange
-        Mock<ISettingsService> settingsServiceMock = new();
-        Mock<IHapticService> hapticServiceMock = new();
-        settingsServiceMock.Setup(s => s.HapticsEnabled).Returns(true);
-        settingsServiceMock.Setup(s => s.CoachEnabled).Returns(false);
-        settingsServiceMock.Setup(s => s.UndoButtonVisible).Returns(false);
-        hapticServiceMock.Setup(h => h.IsSupported).Returns(true);
+        ISettingsService settingsServiceMock = Substitute.For<ISettingsService>();
+        IHapticService hapticServiceMock = Substitute.For<IHapticService>();
+        settingsServiceMock.HapticsEnabled.Returns(true);
+        settingsServiceMock.CoachEnabled.Returns(false);
+        settingsServiceMock.UndoButtonVisible.Returns(false);
+        hapticServiceMock.IsSupported.Returns(true);
 
         // Act
         SettingsViewModel viewModel = CreateViewModel(settingsServiceMock, hapticServiceMock);
@@ -152,12 +152,12 @@ public class SettingsViewModelTests
     public void UndoButtonVisible_WhenChanged_SendsMessageAndUpdatesService()
     {
         // Arrange
-        Mock<ISettingsService> settingsServiceMock = new();
-        Mock<IHapticService> hapticServiceMock = new();
-        settingsServiceMock.Setup(s => s.HapticsEnabled).Returns(true);
-        settingsServiceMock.Setup(s => s.CoachEnabled).Returns(false);
-        settingsServiceMock.Setup(s => s.UndoButtonVisible).Returns(true);
-        hapticServiceMock.Setup(h => h.IsSupported).Returns(true);
+        ISettingsService settingsServiceMock = Substitute.For<ISettingsService>();
+        IHapticService hapticServiceMock = Substitute.For<IHapticService>();
+        settingsServiceMock.HapticsEnabled.Returns(true);
+        settingsServiceMock.CoachEnabled.Returns(false);
+        settingsServiceMock.UndoButtonVisible.Returns(true);
+        hapticServiceMock.IsSupported.Returns(true);
 
         var messenger = new WeakReferenceMessenger();
         SettingsViewModel viewModel = CreateViewModel(
@@ -177,7 +177,7 @@ public class SettingsViewModelTests
         viewModel.UndoButtonVisible = false;
 
         // Assert
-        settingsServiceMock.VerifySet(s => s.UndoButtonVisible = false, Times.Once);
+        settingsServiceMock.Received(1).UndoButtonVisible = false;
         Assert.IsNotNull(receivedValue);
         Assert.IsFalse(receivedValue.Value);
 

--- a/test/TwentyFortyEight.ViewModels.Tests/StatsViewModelTests.cs
+++ b/test/TwentyFortyEight.ViewModels.Tests/StatsViewModelTests.cs
@@ -1,5 +1,5 @@
 using CommunityToolkit.Mvvm.Messaging;
-using Moq;
+using NSubstitute;
 using TwentyFortyEight.Core;
 using TwentyFortyEight.ViewModels.Services;
 
@@ -11,37 +11,37 @@ namespace TwentyFortyEight.ViewModels.Tests;
 [TestClass]
 public class StatsViewModelTests
 {
-    private Mock<IStatisticsTracker> _statisticsTrackerMock = null!;
-    private Mock<IAlertService> _alertServiceMock = null!;
-    private Mock<ILocalizationService> _localizationServiceMock = null!;
-    private Mock<ISettingsService> _settingsServiceMock = null!;
+    private IStatisticsTracker _statisticsTrackerMock = null!;
+    private IAlertService _alertServiceMock = null!;
+    private ILocalizationService _localizationServiceMock = null!;
+    private ISettingsService _settingsServiceMock = null!;
     private IMessenger _messenger = null!;
 
     [TestInitialize]
     public void Setup()
     {
-        _statisticsTrackerMock = new Mock<IStatisticsTracker>();
-        _alertServiceMock = new Mock<IAlertService>();
-        _localizationServiceMock = new Mock<ILocalizationService>();
-        _settingsServiceMock = new Mock<ISettingsService>();
+        _statisticsTrackerMock = Substitute.For<IStatisticsTracker>();
+        _alertServiceMock = Substitute.For<IAlertService>();
+        _localizationServiceMock = Substitute.For<ILocalizationService>();
+        _settingsServiceMock = Substitute.For<ISettingsService>();
         _messenger = new WeakReferenceMessenger();
 
         // Setup default statistics
-        _statisticsTrackerMock.Setup(s => s.GetStatistics()).Returns(new GameStatistics());
+        _statisticsTrackerMock.GetStatistics().Returns(new GameStatistics());
 
         // Default mode/scope
-        _settingsServiceMock
-            .SetupGet(s => s.LastActiveGameConfig)
-            .Returns(new GameConfig { Size = 4, WinTile = 2048 });
+        _settingsServiceMock.LastActiveGameConfig.Returns(
+            new GameConfig { Size = 4, WinTile = 2048 }
+        );
     }
 
     private StatsViewModel CreateViewModel()
     {
         return new StatsViewModel(
-            _statisticsTrackerMock.Object,
-            _alertServiceMock.Object,
-            _localizationServiceMock.Object,
-            _settingsServiceMock.Object,
+            _statisticsTrackerMock,
+            _alertServiceMock,
+            _localizationServiceMock,
+            _settingsServiceMock,
             _messenger
         );
     }
@@ -49,9 +49,9 @@ public class StatsViewModelTests
     [TestMethod]
     public void Constructor_SetsBoardSizeDisplay_FromSettings()
     {
-        _settingsServiceMock
-            .SetupGet(s => s.LastActiveGameConfig)
-            .Returns(new GameConfig { Size = 5, WinTile = 2048 });
+        _settingsServiceMock.LastActiveGameConfig.Returns(
+            new GameConfig { Size = 5, WinTile = 2048 }
+        );
 
         var viewModel = CreateViewModel();
 
@@ -72,7 +72,7 @@ public class StatsViewModelTests
             CurrentStreak = 2,
             BestStreak = 3,
         };
-        _statisticsTrackerMock.Setup(s => s.GetStatistics()).Returns(stats);
+        _statisticsTrackerMock.GetStatistics().Returns(stats);
 
         // Act
         var viewModel = CreateViewModel();
@@ -93,10 +93,10 @@ public class StatsViewModelTests
         // Arrange
         GameStatistics initialStats = new() { GamesPlayed = 5 };
         GameStatistics updatedStats = new() { GamesPlayed = 10 };
-        _statisticsTrackerMock.Setup(s => s.GetStatistics()).Returns(initialStats);
+        _statisticsTrackerMock.GetStatistics().Returns(initialStats);
         var viewModel = CreateViewModel();
 
-        _statisticsTrackerMock.Setup(s => s.GetStatistics()).Returns(updatedStats);
+        _statisticsTrackerMock.GetStatistics().Returns(updatedStats);
 
         // Act
         viewModel.RefreshStatistics();
@@ -110,15 +110,13 @@ public class StatsViewModelTests
     {
         // Arrange
         _alertServiceMock
-            .Setup(a =>
-                a.ShowConfirmationAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                )
+            .ShowConfirmationAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>()
             )
-            .ReturnsAsync(true);
+            .Returns(Task.FromResult(true));
 
         var viewModel = CreateViewModel();
 
@@ -126,7 +124,7 @@ public class StatsViewModelTests
         await viewModel.ResetStatisticsCommand.ExecuteAsync(null);
 
         // Assert
-        _statisticsTrackerMock.Verify(s => s.Reset(), Times.Once);
+        _statisticsTrackerMock.Received(1).Reset();
     }
 
     [TestMethod]
@@ -134,15 +132,13 @@ public class StatsViewModelTests
     {
         // Arrange
         _alertServiceMock
-            .Setup(a =>
-                a.ShowConfirmationAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                )
+            .ShowConfirmationAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>()
             )
-            .ReturnsAsync(false);
+            .Returns(Task.FromResult(false));
 
         var viewModel = CreateViewModel();
 
@@ -150,7 +146,7 @@ public class StatsViewModelTests
         await viewModel.ResetStatisticsCommand.ExecuteAsync(null);
 
         // Assert
-        _statisticsTrackerMock.Verify(s => s.Reset(), Times.Never);
+        _statisticsTrackerMock.DidNotReceive().Reset();
     }
 
     [TestMethod]
@@ -158,7 +154,7 @@ public class StatsViewModelTests
     {
         // Arrange
         GameStatistics stats = new() { GamesPlayed = 10, GamesWon = 3 }; // 30% win rate
-        _statisticsTrackerMock.Setup(s => s.GetStatistics()).Returns(stats);
+        _statisticsTrackerMock.GetStatistics().Returns(stats);
 
         // Act
         var viewModel = CreateViewModel();

--- a/test/TwentyFortyEight.ViewModels.Tests/TwentyFortyEight.ViewModels.Tests.csproj
+++ b/test/TwentyFortyEight.ViewModels.Tests/TwentyFortyEight.ViewModels.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TwentyFortyEight.ViewModels.Tests/VictoryViewModelTests.cs
+++ b/test/TwentyFortyEight.ViewModels.Tests/VictoryViewModelTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 using TwentyFortyEight.ViewModels.Services;
 
 namespace TwentyFortyEight.ViewModels.Tests;
@@ -6,26 +6,26 @@ namespace TwentyFortyEight.ViewModels.Tests;
 [TestClass]
 public class VictoryViewModelTests
 {
-    private Mock<IAccessibilitySettingsService> _accessibilitySettingsMock = null!;
-    private Mock<IUserFeedbackService> _userFeedbackMock = null!;
-    private Mock<ILocalizationService> _localizationMock = null!;
+    private IAccessibilitySettingsService _accessibilitySettingsMock = null!;
+    private IUserFeedbackService _userFeedbackMock = null!;
+    private ILocalizationService _localizationMock = null!;
     private VictoryViewModel _viewModel = null!;
 
     [TestInitialize]
     public void Setup()
     {
-        _accessibilitySettingsMock = new Mock<IAccessibilitySettingsService>();
-        _userFeedbackMock = new Mock<IUserFeedbackService>();
-        _localizationMock = new Mock<ILocalizationService>();
+        _accessibilitySettingsMock = Substitute.For<IAccessibilitySettingsService>();
+        _userFeedbackMock = Substitute.For<IUserFeedbackService>();
+        _localizationMock = Substitute.For<ILocalizationService>();
         _localizationMock
-            .Setup(x => x.FormatScore(It.IsAny<int>()))
-            .Returns((int score) => $"Score: {score}");
-        _localizationMock.Setup(x => x.GetVictorySubtitle(false)).Returns("You reached 2048!");
-        _localizationMock.Setup(x => x.GetVictorySubtitle(true)).Returns("You blocked 2048!");
+            .FormatScore(Arg.Any<int>())
+            .Returns(callInfo => $"Score: {callInfo.Arg<int>()}");
+        _localizationMock.GetVictorySubtitle(false).Returns("You reached 2048!");
+        _localizationMock.GetVictorySubtitle(true).Returns("You blocked 2048!");
         _viewModel = new VictoryViewModel(
-            _accessibilitySettingsMock.Object,
-            _userFeedbackMock.Object,
-            _localizationMock.Object
+            _accessibilitySettingsMock,
+            _userFeedbackMock,
+            _localizationMock
         );
     }
 
@@ -40,7 +40,7 @@ public class VictoryViewModelTests
     public void TriggerVictory_WithReduceMotion_SkipsAnimationAndShowsModal()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(true);
 
         // Act
         _viewModel.TriggerVictory(score: 5000);
@@ -50,15 +50,15 @@ public class VictoryViewModelTests
         Assert.IsTrue(_viewModel.State.IsModalVisible);
         Assert.AreEqual(5000, _viewModel.State.Score);
 
-        _userFeedbackMock.Verify(x => x.PerformVictoryHaptic(), Times.Once);
-        _userFeedbackMock.Verify(x => x.AnnounceWin(), Times.Once);
+        _userFeedbackMock.Received(1).PerformVictoryHaptic();
+        _userFeedbackMock.Received(1).AnnounceWin();
     }
 
     [TestMethod]
     public void TriggerVictory_WithoutReduceMotion_StartsAnimationSequence()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(false);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(false);
         bool animationStartRaised = false;
         _viewModel.AnimationStartRequested += (_, _) => animationStartRaised = true;
 
@@ -77,7 +77,7 @@ public class VictoryViewModelTests
     public void ShowModal_SetsModalVisibleAndAnnouncesWin()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(false);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(false);
         _viewModel.TriggerVictory(score: 2048);
 
         // Act
@@ -85,14 +85,14 @@ public class VictoryViewModelTests
 
         // Assert
         Assert.IsTrue(_viewModel.State.IsModalVisible);
-        _userFeedbackMock.Verify(x => x.AnnounceWin(), Times.Once);
+        _userFeedbackMock.Received(1).AnnounceWin();
     }
 
     [TestMethod]
     public void KeepPlayingCommand_ResetsStateAndRaisesEvent()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(true);
         _viewModel.TriggerVictory(score: 2048);
 
         bool keepPlayingRaised = false;
@@ -114,7 +114,7 @@ public class VictoryViewModelTests
     public void NewGameCommand_ResetsStateAndRaisesEvent()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(true);
         _viewModel.TriggerVictory(score: 2048);
 
         bool newGameRaised = false;
@@ -136,13 +136,13 @@ public class VictoryViewModelTests
     public void ShouldReduceMotion_DelegatesToService()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(true);
 
         // Assert
         Assert.IsTrue(_viewModel.ShouldReduceMotion);
 
         // Change mock behavior
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(false);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(false);
 
         // Assert
         Assert.IsFalse(_viewModel.ShouldReduceMotion);
@@ -152,7 +152,7 @@ public class VictoryViewModelTests
     public void TriggerVictory_SetsWinningValue()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(true);
 
         // Act
         _viewModel.TriggerVictory(score: 4096, winningValue: 4096);
@@ -165,21 +165,21 @@ public class VictoryViewModelTests
     public void ScoreDisplayText_ReturnsLocalizedScore()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(true);
 
         // Act
         _viewModel.TriggerVictory(score: 12345);
 
         // Assert
         Assert.AreEqual("Score: 12345", _viewModel.ScoreDisplayText);
-        _localizationMock.Verify(x => x.FormatScore(12345), Times.AtLeastOnce);
+        _localizationMock.Received().FormatScore(12345);
     }
 
     [TestMethod]
     public void TriggerVictory_StandardMode_SetsIsAdversarialModeFalse()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(true);
 
         // Act
         _viewModel.TriggerVictory(score: 2048, isAdversarialMode: false);
@@ -192,7 +192,7 @@ public class VictoryViewModelTests
     public void TriggerVictory_AdversarialMode_SetsIsAdversarialModeTrue()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(true);
 
         // Act
         _viewModel.TriggerVictory(score: 100, isAdversarialMode: true);
@@ -205,35 +205,35 @@ public class VictoryViewModelTests
     public void VictorySubtitleText_StandardMode_ReturnsReachedSubtitle()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(true);
 
         // Act
         _viewModel.TriggerVictory(score: 2048, isAdversarialMode: false);
 
         // Assert
         Assert.AreEqual("You reached 2048!", _viewModel.VictorySubtitleText);
-        _localizationMock.Verify(x => x.GetVictorySubtitle(false), Times.AtLeastOnce);
+        _localizationMock.Received().GetVictorySubtitle(false);
     }
 
     [TestMethod]
     public void VictorySubtitleText_AdversarialMode_ReturnsBlockedSubtitle()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(true);
 
         // Act
         _viewModel.TriggerVictory(score: 100, isAdversarialMode: true);
 
         // Assert
         Assert.AreEqual("You blocked 2048!", _viewModel.VictorySubtitleText);
-        _localizationMock.Verify(x => x.GetVictorySubtitle(true), Times.AtLeastOnce);
+        _localizationMock.Received().GetVictorySubtitle(true);
     }
 
     [TestMethod]
     public void Reset_ClearsIsAdversarialMode()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(true);
         _viewModel.TriggerVictory(score: 100, isAdversarialMode: true);
         Assert.IsTrue(_viewModel.State.IsAdversarialMode);
 
@@ -248,7 +248,7 @@ public class VictoryViewModelTests
     public void TriggerVictory_NotifiesVictorySubtitleTextChanged()
     {
         // Arrange
-        _accessibilitySettingsMock.Setup(x => x.ShouldReduceMotion()).Returns(true);
+        _accessibilitySettingsMock.ShouldReduceMotion().Returns(true);
         var propertyChangedEvents = new List<string>();
         _viewModel.PropertyChanged += (_, e) => propertyChangedEvents.Add(e.PropertyName!);
 


### PR DESCRIPTION
## Summary
- update the repository's stable NuGet dependencies and MSTest SDK
- replace Moq with NSubstitute 6.2.0 across both unit-test projects
- migrate all substitute configuration, argument matching, call verification, and return sequences
- preserve strict random-source expectations with explicit received-call assertions
- update test guidance so no Moq references remain

## Validation
- `dotnet test --project test/TwentyFortyEight.Core.Tests --framework net10.0` (117 passed)
- `dotnet test --project test/TwentyFortyEight.ViewModels.Tests --framework net10.0 -p:TargetFrameworks=net10.0` (250 passed)
- verified both resolved dependency graphs contain NSubstitute and no Moq